### PR TITLE
chore: change validation patterns

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -53,12 +53,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -108,12 +102,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -160,12 +148,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -185,17 +167,8 @@
         "description": "Delete an OpenFGA store. This does not delete the data associated to it, like tuples or authorization models.",
         "operationId": "DeleteStore",
         "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/DeleteStoreResponse"
-            }
-          },
           "204": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/DeleteStoreResponse"
-            }
+            "description": "A successful response."
           },
           "400": {
             "description": "Request failed due to invalid input.",
@@ -213,12 +186,6 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -264,12 +231,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -295,17 +256,8 @@
         "description": "The Write Assertions API will add new assertions for an authorization model id, or overwrite the existing ones. An assertion is an object that contains a tuple key, and the expectation of whether a call to the Check API of that tuple key will return true or false. ",
         "operationId": "WriteAssertions",
         "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/WriteAssertionsResponse"
-            }
-          },
           "204": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/WriteAssertionsResponse"
-            }
+            "description": "A successful response."
           },
           "400": {
             "description": "Request failed due to invalid input.",
@@ -323,12 +275,6 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -403,12 +349,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -441,12 +381,6 @@
         "description": "The POST authorization-model API will update the authorization model for a certain store.\nPath parameter `store_id` and `type_definitions` array in the body are required.  Each item in the `type_definitions` array is a type definition as specified in the field `type_definition`.\nThe response will return the authorization model's ID in the `id` field.\n\n## Example\nTo update the authorization model with a single `document` authorization model, call POST authorization-models API with the body: \n```json\n{\n  \"type_definitions\":[\n    {\n      \"type\":\"document\",\n      \"relations\":{\n        \"reader\":{\n          \"union\":{\n            \"child\":[\n              {\n                \"this\":{}\n              },\n              {\n                \"computedUserset\":{\n                  \"object\":\"\",\n                  \"relation\":\"writer\"\n                }\n              }\n            ]\n          }\n        },\n        \"writer\":{\n          \"this\":{}\n        }\n      }\n    }\n  ]\n}\n```\nOpenFGA's response will include the version id for this authorization model, which will look like \n```\n{\"authorization_model_id\": \"01G50QVV17PECNVAHX1GG4Y5NC\"}\n```\n",
         "operationId": "WriteAuthorizationModel",
         "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/WriteAuthorizationModelResponse"
-            }
-          },
           "201": {
             "description": "A successful response.",
             "schema": {
@@ -469,12 +403,6 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -528,12 +456,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -583,12 +505,6 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -652,12 +568,6 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -729,12 +639,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -795,12 +699,6 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -872,12 +770,6 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
-            }
           }
         },
         "parameters": [
@@ -941,12 +833,6 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Status"
             }
           }
         },

--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -502,7 +502,7 @@
     "/stores/{store_id}/authorization-models/{id}": {
       "get": {
         "summary": "Return a particular version of an authorization model",
-        "description": "The GET authorization-models by ID API will return a particular version of authorization model that had been configured for a certain store.  \nPath parameter `store_id` and `id` are required.\nThe response will return the authorization model for the particular version.\n\n## Example\nTo retrieve the authorization model with ID `1yunpF9DkzXMzm0dHrsCuWsooEV` for the store, call the GET authorization-models by ID API with `1yunpF9DkzXMzm0dHrsCuWsooEV` as the `id` path parameter.  The API will return:\n```json\n{\n  \"authorization_model\":{\n    \"id\":\"1yunpF9DkzXMzm0dHrsCuWsooEV\",\n    \"type_definitions\":[\n      {\n        \"type\":\"document\",\n        \"relations\":{\n          \"reader\":{\n            \"union\":{\n              \"child\":[\n                {\n                  \"this\":{}\n                },\n                {\n                  \"computedUserset\":{\n                    \"object\":\"\",\n                    \"relation\":\"writer\"\n                  }\n                }\n              ]\n            }\n          },\n          \"writer\":{\n            \"this\":{}\n          }\n        }\n      }\n    ]\n  }\n}\n```\nIn the above example, there is only 1 type (`document`) with 2 relations (`writer` and `reader`).",
+        "description": "The GET authorization-models by ID API will return a particular version of authorization model that had been configured for a certain store.  \nPath parameter `store_id` and `id` are required.\nThe response will return the authorization model for the particular version.\n\n## Example\nTo retrieve the authorization model with ID `01G5JAVJ41T49E9TT3SKVS7X1J` for the store, call the GET authorization-models by ID API with `01G5JAVJ41T49E9TT3SKVS7X1J` as the `id` path parameter.  The API will return:\n```json\n{\n  \"authorization_model\":{\n    \"id\":\"01G5JAVJ41T49E9TT3SKVS7X1J\",\n    \"type_definitions\":[\n      {\n        \"type\":\"document\",\n        \"relations\":{\n          \"reader\":{\n            \"union\":{\n              \"child\":[\n                {\n                  \"this\":{}\n                },\n                {\n                  \"computedUserset\":{\n                    \"object\":\"\",\n                    \"relation\":\"writer\"\n                  }\n                }\n              ]\n            }\n          },\n          \"writer\":{\n            \"this\":{}\n          }\n        }\n      }\n    ]\n  }\n}\n```\nIn the above example, there is only 1 type (`document`) with 2 relations (`writer` and `reader`).",
         "operationId": "ReadAuthorizationModel",
         "responses": {
           "200": {
@@ -683,7 +683,7 @@
                 },
                 "authorization_model_id": {
                   "type": "string",
-                  "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
+                  "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
                 },
                 "trace": {
                   "type": "boolean",
@@ -756,7 +756,7 @@
                 },
                 "authorization_model_id": {
                   "type": "string",
-                  "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
+                  "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
                 }
               }
             }
@@ -823,7 +823,7 @@
                 },
                 "authorization_model_id": {
                   "type": "string",
-                  "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
+                  "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
                 },
                 "page_size": {
                   "type": "integer",
@@ -972,7 +972,7 @@
                 },
                 "authorization_model_id": {
                   "type": "string",
-                  "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
+                  "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
                 }
               }
             }
@@ -1014,7 +1014,7 @@
     "AuthorizationModel": {
       "type": "object",
       "example": {
-        "id": "1yunpF9DkzXMzm0dHrsCuWsooEV",
+        "id": "01G5JAVJ41T49E9TT3SKVS7X1J",
         "type_definitions": [
           {
             "type": "document",
@@ -1044,7 +1044,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
+          "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
         },
         "type_definitions": {
           "type": "array",
@@ -1344,7 +1344,7 @@
       "properties": {
         "authorization_model_id": {
           "type": "string",
-          "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
+          "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
         },
         "assertions": {
           "type": "array",
@@ -1722,7 +1722,7 @@
       "properties": {
         "authorization_model_id": {
           "type": "string",
-          "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
+          "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
         }
       }
     },

--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -53,6 +53,12 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
           }
         },
         "parameters": [
@@ -102,6 +108,12 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
           }
         },
         "parameters": [
@@ -148,6 +160,12 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
           }
         },
         "parameters": [
@@ -167,8 +185,17 @@
         "description": "Delete an OpenFGA store. This does not delete the data associated to it, like tuples or authorization models.",
         "operationId": "DeleteStore",
         "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/DeleteStoreResponse"
+            }
+          },
           "204": {
-            "description": "A successful response."
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/DeleteStoreResponse"
+            }
           },
           "400": {
             "description": "Request failed due to invalid input.",
@@ -186,6 +213,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -231,6 +264,12 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
           }
         },
         "parameters": [
@@ -256,8 +295,17 @@
         "description": "The Write Assertions API will add new assertions for an authorization model id, or overwrite the existing ones. An assertion is an object that contains a tuple key, and the expectation of whether a call to the Check API of that tuple key will return true or false. ",
         "operationId": "WriteAssertions",
         "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WriteAssertionsResponse"
+            }
+          },
           "204": {
-            "description": "A successful response."
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WriteAssertionsResponse"
+            }
           },
           "400": {
             "description": "Request failed due to invalid input.",
@@ -275,6 +323,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -322,8 +376,8 @@
     },
     "/stores/{store_id}/authorization-models": {
       "get": {
-        "summary": "Return all the authorization model IDs for a particular store",
-        "description": "The GET authorization-models API will return all the IDs of the authorization models for a certain store.\nPath parameter `store_id` is required.\nOpenFGA's response will contain an array of all authorization model IDs, sorted in descending order of creation.\n\n## Example\nAssume that the store's authorization model has been configured twice.  To get all the IDs of the authorization models that had been created in this store, call GET authorization-models.  The API will return a response that looks like:\n```json\n{\n  \"authorization_model_ids\": [\n      \"1yunpF9DkzXMzm0dHrsCuWsooEV\",\n      \"1yundoHpJHlodgn4EOVar2DhmKp\"\n  ]\n}\n```\nIf there are more authorization model IDs available, the response will contain an extra field `continuation_token`:\n```json\n{\n  \"authorization_model_ids\": [\n      \"1yunpF9DkzXMzm0dHrsCuWsooEV\",\n      \"1yundoHpJHlodgn4EOVar2DhmKp\"\n  ],\n  \"continuation_token\": \"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\"\n}\n```\n",
+        "summary": "Return all the authorization models for a particular store",
+        "description": "The GET authorization-models API will return all the authorization models for a certain store.\nPath parameter `store_id` is required.\nOpenFGA's response will contain an array of all authorization models, sorted in descending order of creation.\n\n## Example\nAssume that a store's authorization model has been configured twice. To get all the authorization models that have been created in this store, call GET authorization-models. The API will return a response that looks like:\n```json\n{\n  \"authorization_models\": [\n    {\n      \"id\": \"01G50QVV17PECNVAHX1GG4Y5NC\",\n      \"type_definitions\": [...]\n    },\n    {\n      \"id\": \"01G4ZW8F4A07AKQ8RHSVG9RW04\",\n      \"type_definitions\": [...]\n    },\n  ]\n}\n```\nIf there are more authorization models available, the response will contain an extra field `continuation_token`:\n```json\n{\n  \"authorization_models\": [\n    {\n      \"id\": \"01G50QVV17PECNVAHX1GG4Y5NC\",\n      \"type_definitions\": [...]\n    },\n    {\n      \"id\": \"01G4ZW8F4A07AKQ8RHSVG9RW04\",\n      \"type_definitions\": [...]\n    },\n  ]\n  \"continuation_token\": \"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\"\n}\n```\n",
         "operationId": "ReadAuthorizationModels",
         "responses": {
           "200": {
@@ -348,6 +402,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -378,9 +438,15 @@
       },
       "post": {
         "summary": "Create a new authorization model",
-        "description": "The POST authorization-model API will update the authorization model for a certain store.\nPath parameter `store_id` and `type_definitions` array in the body are required.  Each item in the `type_definitions` array is a type definition as specified in the field `type_definition`.\nThe response will return the authorization model's ID in the `id` field.\n\n## Example\nTo update the authorization model with a single `document` authorization model, call POST authorization-models API with the body: \n```json\n{\n  \"type_definitions\":[\n    {\n      \"type\":\"document\",\n      \"relations\":{\n        \"reader\":{\n          \"union\":{\n            \"child\":[\n              {\n                \"this\":{\n\n                }\n              },\n              {\n                \"computedUserset\":{\n                  \"object\":\"\",\n                  \"relation\":\"writer\"\n                }\n              }\n            ]\n          }\n        },\n        \"writer\":{\n          \"this\":{\n\n          }\n        }\n      }\n    }\n  ]\n}\n```\nOpenFGA's response will include the version id for this authorization model, which will look like \n```\n{\"authorization_model_id\": \"1yunpF9DkzXMzm0dHrsCuWsooEV\"}\n```\n",
+        "description": "The POST authorization-model API will update the authorization model for a certain store.\nPath parameter `store_id` and `type_definitions` array in the body are required.  Each item in the `type_definitions` array is a type definition as specified in the field `type_definition`.\nThe response will return the authorization model's ID in the `id` field.\n\n## Example\nTo update the authorization model with a single `document` authorization model, call POST authorization-models API with the body: \n```json\n{\n  \"type_definitions\":[\n    {\n      \"type\":\"document\",\n      \"relations\":{\n        \"reader\":{\n          \"union\":{\n            \"child\":[\n              {\n                \"this\":{}\n              },\n              {\n                \"computedUserset\":{\n                  \"object\":\"\",\n                  \"relation\":\"writer\"\n                }\n              }\n            ]\n          }\n        },\n        \"writer\":{\n          \"this\":{}\n        }\n      }\n    }\n  ]\n}\n```\nOpenFGA's response will include the version id for this authorization model, which will look like \n```\n{\"authorization_model_id\": \"01G50QVV17PECNVAHX1GG4Y5NC\"}\n```\n",
         "operationId": "WriteAuthorizationModel",
         "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WriteAuthorizationModelResponse"
+            }
+          },
           "201": {
             "description": "A successful response.",
             "schema": {
@@ -403,6 +469,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -456,6 +528,12 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
           }
         },
         "parameters": [
@@ -505,6 +583,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -568,6 +652,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -639,6 +729,12 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
           }
         },
         "parameters": [
@@ -700,6 +796,12 @@
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
             }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
           }
         },
         "parameters": [
@@ -743,6 +845,8 @@
     },
     "/stores/{store_id}/read-tuples": {
       "post": {
+        "summary": "Read all the tuples from a given store",
+        "description": "The GET read-tuples API will return a paginated list of tuples that exist in a given store. The response will include a continuation token if there are more tuples to be returned.",
         "operationId": "ReadTuples",
         "responses": {
           "200": {
@@ -767,6 +871,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -831,6 +941,12 @@
             "description": "Request failed due to internal server error.",
             "schema": {
               "$ref": "#/definitions/InternalErrorMessageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
             }
           }
         },
@@ -897,9 +1013,38 @@
     },
     "AuthorizationModel": {
       "type": "object",
+      "example": {
+        "id": "1yunpF9DkzXMzm0dHrsCuWsooEV",
+        "type_definitions": [
+          {
+            "type": "document",
+            "relations": {
+              "reader": {
+                "union": {
+                  "child": [
+                    {
+                      "this": {}
+                    },
+                    {
+                      "computedUserset": {
+                        "object": "",
+                        "relation": "writer"
+                      }
+                    }
+                  ]
+                }
+              },
+              "writer": {
+                "this": {}
+              }
+            }
+          }
+        ]
+      },
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "example": "1yunpF9DkzXMzm0dHrsCuWsooEV"
         },
         "type_definitions": {
           "type": "array",
@@ -953,7 +1098,8 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "example": "my-store-name"
         }
       }
     },
@@ -961,7 +1107,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "example": "01YCP46JKYM8FJCQ37NMBYHE5X"
         },
         "name": {
           "type": "string"
@@ -1047,7 +1194,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "example": "01YCP46JKYM8FJCQ37NMBYHE5X"
         },
         "name": {
           "type": "string"
@@ -1119,7 +1267,8 @@
           }
         },
         "continuation_token": {
-          "type": "string"
+          "type": "string",
+          "example": "eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ=="
         }
       }
     },
@@ -1391,15 +1540,61 @@
     },
     "TypeDefinition": {
       "type": "object",
+      "example": {
+        "type": "document",
+        "relations": {
+          "reader": {
+            "union": {
+              "child": [
+                {
+                  "this": {}
+                },
+                {
+                  "computedUserset": {
+                    "object": "",
+                    "relation": "writer"
+                  }
+                }
+              ]
+            }
+          },
+          "writer": {
+            "this": {}
+          }
+        }
+      },
       "properties": {
         "type": {
           "type": "string",
+          "example": "document",
           "required": [
             "type"
           ]
         },
         "relations": {
           "type": "object",
+          "example": {
+            "relations": {
+              "reader": {
+                "union": {
+                  "child": [
+                    {
+                      "this": {}
+                    },
+                    {
+                      "computedUserset": {
+                        "object": "",
+                        "relation": "writer"
+                      }
+                    }
+                  ]
+                }
+              },
+              "writer": {
+                "this": {}
+              }
+            }
+          },
           "additionalProperties": {
             "$ref": "#/definitions/Userset"
           },

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -7,8 +7,20 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 import "validate/validate.proto";
 
 message AuthorizationModel {
-  string id = 1;
-  repeated TypeDefinition type_definitions = 2 [json_name = "type_definitions"];
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    example: "{\"id\": \"1yunpF9DkzXMzm0dHrsCuWsooEV\", \"type_definitions\":[{\"type\":\"document\",\"relations\":{\"reader\":{\"union\":{\"child\":[{\"this\":{}},{\"computedUserset\":{\"object\":\"\",\"relation\":\"writer\"}}]}},\"writer\":{\"this\":{}}}}]}"
+  };
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+    },
+    (validate.rules).string = {
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    }
+  ];
+  repeated TypeDefinition type_definitions = 2 [
+    json_name = "type_definitions"
+  ];
 }
 
 message TypeDefinitions {
@@ -25,13 +37,19 @@ message TypeDefinitions {
 }
 
 message TypeDefinition {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    example: "{\"type\":\"document\",\"relations\":{\"reader\":{\"union\":{\"child\":[{\"this\":{}},{\"computedUserset\":{\"object\":\"\",\"relation\":\"writer\"}}]}},\"writer\":{\"this\":{}}}}"
+  };
   string type = 1 [
     (validate.rules).string = {
       min_len: 1,
       max_bytes: 254,
       pattern: "^[^:#@\\s]*$"
     },
-    (google.api.field_behavior) = REQUIRED
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"document\""
+    }
   ];
   map<string, Userset> relations = 2 [
     (validate.rules).map = {
@@ -42,7 +60,10 @@ message TypeDefinition {
       max_bytes: 50,
       pattern: "^[^:#@\\s]*$"
     },
-    (google.api.field_behavior) = REQUIRED
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "{\"relations\":{\"reader\":{\"union\":{\"child\":[{\"this\":{}},{\"computedUserset\":{\"object\":\"\",\"relation\":\"writer\"}}]}},\"writer\":{\"this\":{}}}}"
+    }
   ];
 }
 

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -8,11 +8,11 @@ import "validate/validate.proto";
 
 message AuthorizationModel {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
-    example: "{\"id\": \"1yunpF9DkzXMzm0dHrsCuWsooEV\", \"type_definitions\":[{\"type\":\"document\",\"relations\":{\"reader\":{\"union\":{\"child\":[{\"this\":{}},{\"computedUserset\":{\"object\":\"\",\"relation\":\"writer\"}}]}},\"writer\":{\"this\":{}}}}]}"
+    example: "{\"id\": \"01G5JAVJ41T49E9TT3SKVS7X1J\", \"type_definitions\":[{\"type\":\"document\",\"relations\":{\"reader\":{\"union\":{\"child\":[{\"this\":{}},{\"computedUserset\":{\"object\":\"\",\"relation\":\"writer\"}}]}},\"writer\":{\"this\":{}}}}]}"
   };
   string id = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     },
     (validate.rules).string = {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -42,9 +42,7 @@ message TypeDefinition {
   };
   string type = 1 [
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 254,
-      pattern: "^[^:#@\\s]*$"
+      pattern: "^[^:#@\\s]{1,254}$"
     },
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
@@ -56,9 +54,7 @@ message TypeDefinition {
       min_pairs: 1
     },
     (validate.rules).map.keys.string = {
-      min_len: 1,
-      max_bytes: 50,
-      pattern: "^[^:#@\\s]*$"
+      pattern: "^[^:#@\\s]{1,50}$"
     },
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {

--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -10,8 +10,7 @@ import "validate/validate.proto";
 message TupleKey {
   string object = 1 [
     (validate.rules).string = {
-      max_bytes: 256,
-      pattern: "^[^\\s]*$"
+      pattern: "^[^\\s]{,256}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 256,
@@ -20,8 +19,7 @@ message TupleKey {
   ];
   string relation = 2 [
     (validate.rules).string = {
-      max_bytes: 50,
-      pattern: "^[^:#@\\s]*$"
+      pattern: "^[^:#@\\s]{,50}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 50,

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -1046,8 +1046,7 @@ message ReadChangesRequest {
   ];
 
   string type = 2 [(validate.rules).string = {
-    max_bytes: 254,
-    pattern: "^[^:#\\s]*$"
+    pattern: "^[^:#\\s]{,254}$"
   }];
 
   google.protobuf.Int32Value page_size = 3 [

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -663,12 +663,15 @@ service OpenFGAService {
   }
 }
 
+// Note: store_id is a ULID using pattern ^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$
+// which excludes I, L, O, and U
+// because of https://github.com/ulid/spec#encoding
+
 message ReadRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -724,8 +727,7 @@ message WriteRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_len: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -751,8 +753,7 @@ message CheckRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -794,8 +795,7 @@ message ExpandRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -824,8 +824,7 @@ message ReadAuthorizationModelRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -843,8 +842,7 @@ message WriteAuthorizationModelRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -868,8 +866,7 @@ message ReadAuthorizationModelsRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -915,8 +912,7 @@ message ReadTuplesRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -959,8 +955,7 @@ message WriteAssertionsRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -998,8 +993,7 @@ message ReadAssertionsRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -1037,8 +1031,7 @@ message ReadChangesRequest {
   string store_id = 1 [
     json_name = "store_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 256
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
@@ -1100,6 +1093,9 @@ message DeleteStoreRequest {
     json_name = "store_id",
     (validate.rules).string = {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
     }
   ];
 }
@@ -1111,6 +1107,9 @@ message GetStoreRequest {
     json_name = "store_id",
     (validate.rules).string = {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
     }
   ];
 }

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -381,13 +381,13 @@ service OpenFGAService {
         "Path parameter `store_id` and `id` are required.\n"
         "The response will return the authorization model for the particular version.\n\n"
         "## Example\n"
-        "To retrieve the authorization model with ID `1yunpF9DkzXMzm0dHrsCuWsooEV` for the store, "
-        "call the GET authorization-models by ID API with `1yunpF9DkzXMzm0dHrsCuWsooEV` as the "
+        "To retrieve the authorization model with ID `01G5JAVJ41T49E9TT3SKVS7X1J` for the store, "
+        "call the GET authorization-models by ID API with `01G5JAVJ41T49E9TT3SKVS7X1J` as the "
         "`id` path parameter.  The API will return:\n"
         "```json\n"
         "{\n"
         "  \"authorization_model\":{\n"
-        "    \"id\":\"1yunpF9DkzXMzm0dHrsCuWsooEV\",\n"
+        "    \"id\":\"01G5JAVJ41T49E9TT3SKVS7X1J\",\n"
         "    \"type_definitions\":[\n"
         "      {\n"
         "        \"type\":\"document\",\n"
@@ -689,7 +689,7 @@ message ReadRequest {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 
@@ -746,7 +746,7 @@ message WriteRequest {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 }
@@ -777,7 +777,7 @@ message CheckRequest {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 
@@ -819,7 +819,7 @@ message ExpandRequest {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 }
@@ -867,7 +867,7 @@ message WriteAuthorizationModelResponse {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 }
@@ -978,7 +978,7 @@ message WriteAssertionsRequest {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 
@@ -1015,7 +1015,7 @@ message ReadAssertionsRequest {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 }
@@ -1027,7 +1027,7 @@ message ReadAssertionsResponse {
       pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
+      example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""
     }
   ];
 

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -685,7 +685,9 @@ message ReadRequest {
 
   string authorization_model_id = 3 [
     json_name = "authorization_model_id",
-    (validate.rules).string.max_len = 26,
+    (validate.rules).string = {
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
     }
@@ -740,7 +742,9 @@ message WriteRequest {
 
   string authorization_model_id = 4 [
     json_name = "authorization_model_id",
-    (validate.rules).string.max_len = 26,
+    (validate.rules).string = {
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
     }
@@ -769,7 +773,9 @@ message CheckRequest {
 
   string authorization_model_id = 4 [
     json_name = "authorization_model_id",
-    (validate.rules).string.max_len = 26,
+    (validate.rules).string = {
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
     }
@@ -809,7 +815,9 @@ message ExpandRequest {
 
   string authorization_model_id = 3 [
     json_name = "authorization_model_id",
-    (validate.rules).string.max_len = 26,
+    (validate.rules).string = {
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
     }
@@ -855,7 +863,9 @@ message WriteAuthorizationModelRequest {
 message WriteAuthorizationModelResponse {
   string authorization_model_id = 1 [
     json_name = "authorization_model_id",
-    (validate.rules).string.max_len = 26,
+    (validate.rules).string = {
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
     }
@@ -965,8 +975,7 @@ message WriteAssertionsRequest {
   string authorization_model_id = 2 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 26
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
@@ -1003,8 +1012,7 @@ message ReadAssertionsRequest {
   string authorization_model_id = 2 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 26
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
@@ -1016,8 +1024,7 @@ message ReadAssertionsResponse {
   string authorization_model_id = 1 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      min_len: 1,
-      max_bytes: 26
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "\"1yunpF9DkzXMzm0dHrsCuWsooEV\""
@@ -1076,13 +1083,22 @@ message ReadChangesResponse {
 }
 
 message CreateStoreRequest {
-  string name = 1 [(validate.rules).string = {
-    pattern: "^[a-zA-Z0-9\\s\\.\\-\\/^_&@]{3,64}$"
-  }];
+  string name = 1 [
+    (validate.rules).string = {
+      pattern: "^[a-zA-Z0-9\\s\\.\\-\\/^_&@]{3,64}$"
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"my-store-name\""
+    }
+  ];
 }
 
 message CreateStoreResponse {
-  string id = 1;
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
+    }
+  ];
   string name = 2;
   google.protobuf.Timestamp created_at = 3 [json_name = "created_at"];
   google.protobuf.Timestamp updated_at = 4 [json_name = "updated_at"];
@@ -1115,7 +1131,11 @@ message GetStoreRequest {
 }
 
 message GetStoreResponse {
-  string id = 1;
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"01YCP46JKYM8FJCQ37NMBYHE5X\""
+    }
+  ];
   string name = 2;
   google.protobuf.Timestamp created_at = 3 [json_name = "created_at"];
   google.protobuf.Timestamp updated_at = 4 [json_name = "updated_at"];
@@ -1131,7 +1151,10 @@ message ListStoresRequest {
   ];
   string continuation_token = 2 [
     json_name = "continuation_token",
-    (validate.rules).string.max_bytes = 5120
+    (validate.rules).string.max_bytes = 5120,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\""
+    }
   ];
 }
 
@@ -1139,6 +1162,9 @@ message ListStoresResponse {
   repeated openfga.v1.Store stores = 1;
   string continuation_token = 2 [
     json_name = "continuation_token",
-    (validate.rules).string.max_bytes = 5120
+    (validate.rules).string.max_bytes = 5120,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\""
+    }
   ];
 }


### PR DESCRIPTION
You can ignore the `swagger.json` file when reviewing this PR, as it's generated by `buf generate`.

## Description

- Add a few examples in the proto files
- Whenever we have a mix of `min_len/max_len` and `pattern` validation, remove the `min_len` and `max_len` in favor of an updated pattern that includes the length. See https://github.com/envoyproxy/protoc-gen-validate/issues/79
- Both `store_id` and `authorization_model_id` are generated with https://github.com/oklog/ulid, which generates 26 characters. Change the validation for these fields

## References
n/a

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
