### PR TITLE
chore: add Go source code generation plugins for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 .DS_Store
 .env
+proto/
+*.pb.go

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ To generate source code from the protobuf definitions contained in this project 
 ```
 
 The command above will generate source code in the `proto/` directory.
+
+## Generating OpenAPI Documentation
+To generate the OpenAPI documentation from the protobuf sources you can run the following command:
+
+```bash
+./buf.gen.yaml
+./scripts/update_swagger.sh docs/openapiv2/apidocs.swagger.json
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project contains the definitions of [Protocol Buffers](https://developers.g
 are pushed to the [`buf.build/openfga/api`](https://buf.build/openfga/api) repository in the Buf Registry.
 
 ## Building the Generated Sources
-To generated source code from the protobuf definitions contained in this project you can run the following command:
+To generate source code from the protobuf definitions contained in this project you can run the following command:
 
 ```bash
 ./buf.gen.yaml

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ This project contains the definitions of [Protocol Buffers](https://developers.g
 
 [Buf](https://github.com/bufbuild/buf) is used to manage, package, and generate source code from the protocol buffer definitions. The API definitions
 are pushed to the [`buf.build/openfga/api`](https://buf.build/openfga/api) repository in the Buf Registry.
+
+## Building the Generated Sources
+To generated source code from the protobuf definitions contained in this project you can run the following command:
+
+```bash
+./buf.gen.yaml
+```
+
+this will put the generated source code in the `proto/` directory.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ To generate source code from the protobuf definitions contained in this project 
 ./buf.gen.yaml
 ```
 
-this will put the generated source code in the `proto/` directory.
+The command above will generate source code in the `proto/` directory.

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -8,20 +8,20 @@ managed:
     except:
       - buf.build/googleapis/googleapis
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/go:v1.27.1-1
+  - remote: buf.build/protocolbuffers/plugins/go:v1.28.0-1
     out: proto/
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc/plugins/go:v1.1.0-1
+  - remote: buf.build/grpc/plugins/go:v1.2.0-1
     out: proto/
     opt:
       - paths=source_relative
-  - remote: buf.build/jirkad/plugins/protoc-gen-validate:v0.6.1
+  - remote: buf.build/jirkad/plugins/protoc-gen-validate:v0.6.7
     out: proto/
     opt:
       - paths=source_relative
       - lang=go
-  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.8.0-1
+  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.10.0-1
     out: proto/
     opt:
       - paths=source_relative

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -8,6 +8,24 @@ managed:
     except:
       - buf.build/googleapis/googleapis
 plugins:
+  - remote: buf.build/protocolbuffers/plugins/go:v1.27.1-1
+    out: proto/
+    opt:
+      - paths=source_relative
+  - remote: buf.build/grpc/plugins/go:v1.1.0-1
+    out: proto/
+    opt:
+      - paths=source_relative
+  - remote: buf.build/jirkad/plugins/protoc-gen-validate:v0.6.1
+    out: proto/
+    opt:
+      - paths=source_relative
+      - lang=go
+  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.8.0-1
+    out: proto/
+    opt:
+      - paths=source_relative
+      - logtostderr=true
   - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.10.0-1
     out: docs/openapiv2
     opt:


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
These changes introduce Go source code generation plugins to the `buf.gen.yaml` file so that developers can build the sources from the protobufs for development and testing. Any source code generated from the protobufs is ignored in the `.gitignore` file because the goal is to import the generated sources from the Buf Remote Registry instead. This is just to assist with local development workflows where you want to test protobuf changes before publishing a new version.

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
