### PR TITLE
fix: quantifiers in regexes

### DIFF
--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -10,7 +10,7 @@ import "validate/validate.proto";
 message TupleKey {
   string object = 1 [
     (validate.rules).string = {
-      pattern: "^[^\\s]{,256}$"
+      pattern: "^[^\\s]{0,256}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 256,
@@ -19,7 +19,7 @@ message TupleKey {
   ];
   string relation = 2 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{,50}$"
+      pattern: "^[^:#@\\s]{0,50}$"
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 50,

--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -10,7 +10,8 @@ import "validate/validate.proto";
 message TupleKey {
   string object = 1 [
     (validate.rules).string = {
-      pattern: "^[^\\s]{0,256}$"
+      pattern: "^[^\\s]{2,256}$",
+      ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 256,
@@ -19,7 +20,8 @@ message TupleKey {
   ];
   string relation = 2 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{0,50}$"
+      pattern: "^[^:#@\\s]{1,50}$",
+      ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 50,

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -1046,7 +1046,7 @@ message ReadChangesRequest {
   ];
 
   string type = 2 [(validate.rules).string = {
-    pattern: "^[^:#\\s]{,254}$"
+    pattern: "^[^:#\\s]{0,254}$"
   }];
 
   google.protobuf.Int32Value page_size = 3 [

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -1046,7 +1046,8 @@ message ReadChangesRequest {
   ];
 
   string type = 2 [(validate.rules).string = {
-    pattern: "^[^:#\\s]{0,254}$"
+    pattern: "^[^:#\\s]{1,254}$",
+    ignore_empty: true
   }];
 
   google.protobuf.Int32Value page_size = 3 [


### PR DESCRIPTION
From Slack:

```
Writing/checking against our github tuples is now throwing and invalid regex error:

rpc error: code = InvalidArgument desc = invalid CheckRequest.TupleKey: embedded message failed validation | caused by: invalid TupleKey.Object: value does not match regex pattern \"^[^\\\\s]{,256}$\"

But it’s triggering for checks as simple as:

curl -s -X POST http://localhost:8080/stores/$STORE_ID/check -d '{ "tuple_key": { "user": "anne", "relation": "maintainer", "object": "repo:a" } }'

repo:a should be a valid object
```