### PR TITLE
fix: require `TypeDefinitions` field in `WriteAuthorizationModel` RPC

### DIFF
--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -861,7 +861,9 @@ message WriteAuthorizationModelRequest {
     }
   ];
 
-  TypeDefinitions type_definitions = 2;
+  TypeDefinitions type_definitions = 2 [
+    (validate.rules).message.required = true
+  ];
 }
 
 message WriteAuthorizationModelResponse {


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR adds field validations to the `WriteAuthorizationModel` RPC that requires the `TypeDefinitions` field be provided in the request.

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
