### PR TITLE
fix: correct create_store http status code

### DIFF
--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -603,6 +603,17 @@ service OpenFGAService {
       ]
       operation_id: "CreateStore"
       description: "Create a unique OpenFGA store which will be used to store authorization models and relationship tuples."
+      responses: {
+        key: "201"
+        value: {
+          description: "A successful response."
+          schema: {
+            json_schema: {
+              ref: ".openfga.v1.CreateStoreResponse"
+            }
+          }
+        }
+      }
     };
   }
 


### PR DESCRIPTION
## Description

The correct create_store status code is 201, not 200.

## References
- Close https://github.com/openfga/api/issues/13

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
