### PR TITLE
ci: only push new Buf module when relevant .proto files have changed

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - openfga/**/*.proto
+      - buf.md
+      - buf.lock
+      - README.md
 
 jobs:
   build:
@@ -12,11 +17,6 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           version: '1.4.0'
-#      - uses: bufbuild/buf-lint-action@v1
-#      - uses: bufbuild/buf-breaking-action@v1
-#        with:
-#          # The 'main' branch of the GitHub repository that defines the module.
-#          against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main,ref=HEAD~1'
       - uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This changes our `push` action so that we push new Buf modules to the Buf Registry only on changes to protobuf files. If no doc or protobuf files have changed that the Buf Registry depends on, then the push action will be skipped.

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
