### PR TITLE
chore: add Object definition to openfga.v1 protobuf API

### DIFF
--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -7,6 +7,16 @@ import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "validate/validate.proto";
 
+// Object represents an OpenFGA Object.
+//
+// An Object is composed of a type and identifier (e.g. 'document:1')
+//
+// See https://openfga.dev/docs/concepts#what-is-an-object
+message Object {
+  string type = 1;
+  string id = 2;
+}
+
 message TupleKey {
   string object = 1 [
     (validate.rules).string = {

--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -13,8 +13,22 @@ import "validate/validate.proto";
 //
 // See https://openfga.dev/docs/concepts#what-is-an-object
 message Object {
-  string type = 1;
-  string id = 2;
+  string type = 1 [
+    (validate.rules).string = {
+      pattern: "^[^:#@\\s]{1,254}$"
+    },
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"document\""
+    }
+  ];
+
+  string id = 2 [
+    (validate.rules).string = {
+      pattern: "[^#:\\s]+$"
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message TupleKey {


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This adds a protobuf definition for Object types in the OpenFGA API. This will make it easier to pass around objects instead of passing around OpenFGA objects formatted as strings such as `document:1`. I believe this will make our code easier to manage and read. 

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
