### PR TITLE
refactor: simplify tuple to userset proto object

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -1108,6 +1108,14 @@
         }
       }
     },
+    "ComputedUserset": {
+      "type": "object",
+      "properties": {
+        "relation": {
+          "type": "string"
+        }
+      }
+    },
     "ContextualTupleKeys": {
       "type": "object",
       "properties": {
@@ -1357,17 +1365,6 @@
       ],
       "default": "no_not_found_error"
     },
-    "ObjectRelation": {
-      "type": "object",
-      "properties": {
-        "object": {
-          "type": "string"
-        },
-        "relation": {
-          "type": "string"
-        }
-      }
-    },
     "PathUnknownErrorMessageResponse": {
       "type": "object",
       "example": {
@@ -1591,6 +1588,14 @@
       "default": "TUPLE_OPERATION_WRITE",
       "title": "buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX"
     },
+    "Tupleset": {
+      "type": "object",
+      "properties": {
+        "relation": {
+          "type": "string"
+        }
+      }
+    },
     "TypeDefinition": {
       "type": "object",
       "example": {
@@ -1691,7 +1696,7 @@
           "$ref": "#/definitions/DirectUserset"
         },
         "computedUserset": {
-          "$ref": "#/definitions/ObjectRelation"
+          "$ref": "#/definitions/ComputedUserset"
         },
         "tupleToUserset": {
           "$ref": "#/definitions/v1.TupleToUserset"
@@ -1797,11 +1802,11 @@
       "type": "object",
       "properties": {
         "tupleset": {
-          "$ref": "#/definitions/ObjectRelation",
+          "$ref": "#/definitions/Tupleset",
           "title": "The target object/relation"
         },
         "computedUserset": {
-          "$ref": "#/definitions/ObjectRelation"
+          "$ref": "#/definitions/ComputedUserset"
         }
       }
     }

--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -1167,10 +1167,6 @@
     "DeleteStoreResponse": {
       "type": "object"
     },
-    "DirectUserset": {
-      "type": "object",
-      "description": "A DirectUserset is a sentinel message for referencing\nthe direct members specified by an object/relation mapping."
-    },
     "ErrorCode": {
       "type": "string",
       "enum": [
@@ -1280,6 +1276,17 @@
         },
         "message": {
           "type": "string"
+        }
+      }
+    },
+    "Intersection": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UsersetRewrite"
+          }
         }
       }
     },
@@ -1513,6 +1520,9 @@
       },
       "description": "The response for a StreamedListObjects RPC."
     },
+    "This": {
+      "type": "object"
+    },
     "Tuple": {
       "type": "object",
       "properties": {
@@ -1654,7 +1664,7 @@
             }
           },
           "additionalProperties": {
-            "$ref": "#/definitions/Userset"
+            "$ref": "#/definitions/UsersetRewrite"
           },
           "required": [
             "relations"
@@ -1678,6 +1688,17 @@
         }
       }
     },
+    "Union": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UsersetRewrite"
+          }
+        }
+      }
+    },
     "Users": {
       "type": "object",
       "properties": {
@@ -1689,11 +1710,11 @@
         }
       }
     },
-    "Userset": {
+    "UsersetRewrite": {
       "type": "object",
       "properties": {
         "this": {
-          "$ref": "#/definitions/DirectUserset"
+          "$ref": "#/definitions/This"
         },
         "computedUserset": {
           "$ref": "#/definitions/ComputedUserset"
@@ -1702,10 +1723,10 @@
           "$ref": "#/definitions/v1.TupleToUserset"
         },
         "union": {
-          "$ref": "#/definitions/Usersets"
+          "$ref": "#/definitions/Union"
         },
         "intersection": {
-          "$ref": "#/definitions/Usersets"
+          "$ref": "#/definitions/Intersection"
         },
         "difference": {
           "$ref": "#/definitions/v1.Difference"
@@ -1746,17 +1767,6 @@
         }
       }
     },
-    "Usersets": {
-      "type": "object",
-      "properties": {
-        "child": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Userset"
-          }
-        }
-      }
-    },
     "ValidationErrorMessageResponse": {
       "type": "object",
       "example": {
@@ -1791,10 +1801,10 @@
       "type": "object",
       "properties": {
         "base": {
-          "$ref": "#/definitions/Userset"
+          "$ref": "#/definitions/UsersetRewrite"
         },
         "subtract": {
-          "$ref": "#/definitions/Userset"
+          "$ref": "#/definitions/UsersetRewrite"
         }
       }
     },

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -62,7 +62,7 @@ message TypeDefinition {
 }
 
 message UsersetRewrite {
-  oneof rewrite_oneof {
+  oneof userset_rewrite {
     This this = 1;
     ComputedUserset computed_userset = 2;
     TupleToUserset tuple_to_userset = 3;

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -61,6 +61,35 @@ message TypeDefinition {
   ];
 }
 
+message Userset {
+  oneof userset {
+    DirectUserset this = 1;
+    ComputedUserset computed_userset = 2;
+    TupleToUserset tuple_to_userset = 3;
+    Usersets union = 4;
+    Usersets intersection = 5;
+    Difference difference = 6;
+  }
+}
+
+// A DirectUserset is a sentinel message for referencing
+// the direct members specified by an object/relation mapping.
+message DirectUserset {}
+
+message ComputedUserset {
+  string relation = 1 [(validate.rules).string = { max_bytes: 50 }];
+}
+
+message TupleToUserset {
+  // The target object/relation
+  Tupleset tupleset = 1;
+  ComputedUserset computed_userset = 2;
+}
+
+message Tupleset {
+  string relation = 1 [(validate.rules).string = { max_bytes: 50 }];
+}
+
 message Usersets {
   repeated Userset child = 1;
 }
@@ -75,34 +104,4 @@ message Difference {
     (validate.rules).message.required = true,
     (google.api.field_behavior) = REQUIRED
   ];
-}
-
-message Userset {
-  oneof userset {
-    DirectUserset this = 1;
-    ObjectRelation computed_userset = 2;
-    TupleToUserset tuple_to_userset = 3;
-    Usersets union = 4;
-    Usersets intersection = 5;
-    Difference difference = 6;
-  }
-}
-
-// A DirectUserset is a sentinel message for referencing
-// the direct members specified by an object/relation mapping.
-message DirectUserset {}
-
-message ObjectRelation {
-  string object = 1 [(validate.rules).string = {
-    max_bytes: 256
-  }];
-  string relation = 2 [(validate.rules).string = {
-    max_bytes: 50
-  }];
-}
-
-message TupleToUserset {
-  // The target object/relation
-  ObjectRelation tupleset = 1;
-  ObjectRelation computed_userset = 2;
 }

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -62,7 +62,7 @@ message TypeDefinition {
 }
 
 message UsersetRewrite {
-  oneof ref {
+  oneof rewrite_oneof {
     This this = 1;
     ComputedUserset computed_userset = 2;
     TupleToUserset tuple_to_userset = 3;

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -47,7 +47,7 @@ message TypeDefinition {
       example: "\"document\""
     }
   ];
-  map<string, Userset> relations = 2 [
+  map<string, UsersetRewrite> relations = 2 [
     (validate.rules).map = {
       min_pairs: 1
     },
@@ -61,22 +61,24 @@ message TypeDefinition {
   ];
 }
 
-message Userset {
-  oneof userset {
-    DirectUserset this = 1;
+message UsersetRewrite {
+  oneof ref {
+    This this = 1;
     ComputedUserset computed_userset = 2;
     TupleToUserset tuple_to_userset = 3;
-    Usersets union = 4;
-    Usersets intersection = 5;
+    Union union = 4;
+    Intersection intersection = 5;
     Difference difference = 6;
   }
 }
 
-// A DirectUserset is a sentinel message for referencing
-// the direct members specified by an object/relation mapping.
-message DirectUserset {}
+message This {}
 
 message ComputedUserset {
+  string relation = 1 [(validate.rules).string = { max_bytes: 50 }];
+}
+
+message Tupleset {
   string relation = 1 [(validate.rules).string = { max_bytes: 50 }];
 }
 
@@ -86,21 +88,21 @@ message TupleToUserset {
   ComputedUserset computed_userset = 2;
 }
 
-message Tupleset {
-  string relation = 1 [(validate.rules).string = { max_bytes: 50 }];
+message Union {
+  repeated UsersetRewrite children = 1;
 }
 
-message Usersets {
-  repeated Userset child = 1;
+message Intersection {
+  repeated UsersetRewrite children = 1;
 }
 
 message Difference {
-  Userset base = 1 [
+  UsersetRewrite base = 1 [
     (validate.rules).message.required = true,
     (google.api.field_behavior) = REQUIRED
   ];
 
-  Userset subtract = 2 [
+  UsersetRewrite subtract = 2 [
     (validate.rules).message.required = true,
     (google.api.field_behavior) = REQUIRED
   ];


### PR DESCRIPTION

<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

Previously tupleset and computed_userset used the ObjectRelation object, but since neither of these use the object let's drop it. Also use the correct name "ComputerUserset" and "Tupleset" rather than the vague "ObjectRelation".

Also, since we are already here, rename a few things to be consistent with the Zanzibar paper.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
