### PR TITLE
fix: update buf.lock

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,12 +4,12 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
-    commit: dc09a417d27241f7b069feae2cd74a0e
+    commit: 45685e052c7e406b9fbd441fc7a568a5
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: f3590c56d388417ebbedefae77ac12bf
+    commit: 62f35d8aed1149c291d606d958a7ce32
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: febd9e8be39b4f4b878b9c64bcc203fd
+    commit: bc28b723cd774c32b6fbc77621518765


### PR DESCRIPTION
To fix this: 

```
Failure: buf.build/googleapis/googleapis:80720a488c9a414bb8d4a9f811084989: does not exist
```