### PR TITLE
chore: add Relation type to protobuf definitions for reusability

### DIFF
--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -8,8 +8,12 @@ import "validate/validate.proto";
 
 message AuthorizationModel {
   string id = 1 [
-    (validate.rules).string = { pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$" },
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { example: '"01G5JAVJ41T49E9TT3SKVS7X1J"' }
+    (validate.rules).string = {
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: '"01G5JAVJ41T49E9TT3SKVS7X1J"'
+    }
   ];
 
   string schema_version = 2 [json_name = "schema_version"];
@@ -24,13 +28,19 @@ message AuthorizationModel {
 
 message TypeDefinition {
   string type = 1 [
-    (validate.rules).string = { pattern: "^[^:#@\\s]{1,254}$" },
+    (validate.rules).string = {
+      pattern: "^[^:#@\\s]{1,254}$"
+    },
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { example: '"document"' }
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: '"document"'
+    }
   ];
 
   map<string, Userset> relations = 2 [
-    (validate.rules).map.keys.string = { pattern: "^[^:#@\\s]{1,50}$" },
+    (validate.rules).map.keys.string = {
+      pattern: "^[^:#@\\s]{1,50}$"
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: '{"relations":{"reader":{"union":{"child":[{"this":{}},{"computedUserset":{"object":"","relation":"writer"}}]}},"writer":{"this":{}}}}'
     }
@@ -41,25 +51,51 @@ message TypeDefinition {
   Metadata metadata = 3;
 }
 
+message Relation {
+  string name = 1 [(validate.rules).string = {
+    pattern: "^[^:#@\\s]{1,50}$"
+  }];
+
+  Userset rewrite = 2 [
+    (validate.rules).message.required = true,
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  RelationTypeInfo type_info = 3;
+}
+
+message RelationTypeInfo {
+  repeated RelationReference directly_related_user_types = 1 [json_name = "directly_related_user_types"];
+}
+
 message Metadata {
   map<string, RelationMetadata> relations = 1;
 }
 
 message RelationMetadata {
-  repeated RelationReference directly_related_user_types = 1 [ json_name = "directly_related_user_types" ];
+  repeated RelationReference directly_related_user_types = 1 [json_name = "directly_related_user_types"];
 }
 
 // RelationReference represents a relation of a particular object type (e.g. 'document#viewer').
 message RelationReference {
   string type = 1 [
-    (validate.rules).string = { pattern: "^[^:#@\\s]{1,254}$" },
+    (validate.rules).string = {
+      pattern: "^[^:#@\\s]{1,254}$"
+    },
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { example: '"group"' }
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: '"group"'
+    }
   ];
 
   string relation = 2 [
-    (validate.rules).string = { pattern: "^[^:#@\\s]{1,50}$", ignore_empty: true },
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { example: '"member"' }
+    (validate.rules).string = {
+      pattern: "^[^:#@\\s]{1,50}$",
+      ignore_empty: true
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: '"member"'
+    }
   ];
 }
 

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -973,13 +973,23 @@ message WriteAuthorizationModelRequest {
 
   repeated TypeDefinition type_definitions = 2 [
     json_name = "type_definitions",
-    (validate.rules).repeated = { min_items: 1 },
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = { minimum: 1 }
+    (validate.rules).repeated = {
+      min_items: 1
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      minimum: 1
+    }
   ];
 
   string schema_version = 3 [
     json_name = "schema_version",
-    (validate.rules).string = {in: ["1.0", "1.1"], ignore_empty: true}
+    (validate.rules).string = {
+      in: [
+        "1.0",
+        "1.1"
+      ],
+      ignore_empty: true
+    }
   ];
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Adds the `Relation` type to the protobuf definitions so we can re-use it throughout our code. This will make things more tidy and elegant on the backend where we store a `map[string]*openfgapb.TypeDefinition`. Instead, we can now store `map[string]*openfgapb.Relation` and use that in places, which will reduce the duplication of indexing into two maps all over the place and will allow us to pass around a Relation object where appropriate.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
