### PR TITLE
fix: listobjects validation of parameters

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -732,13 +732,16 @@
                   "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
                 },
                 "type": {
-                  "type": "string"
+                  "type": "string",
+                  "example": "document"
                 },
                 "relation": {
                   "type": "string"
                 },
                 "user": {
-                  "type": "string"
+                  "type": "string",
+                  "example": "anne",
+                  "maxLength": 512
                 },
                 "contextual_tuples": {
                   "$ref": "#/definitions/ContextualTupleKeys"
@@ -944,13 +947,16 @@
                   "example": "01G5JAVJ41T49E9TT3SKVS7X1J"
                 },
                 "type": {
-                  "type": "string"
+                  "type": "string",
+                  "example": "document"
                 },
                 "relation": {
                   "type": "string"
                 },
                 "user": {
-                  "type": "string"
+                  "type": "string",
+                  "example": "anne",
+                  "maxLength": 512
                 },
                 "contextual_tuples": {
                   "$ref": "#/definitions/ContextualTupleKeys"

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -726,10 +726,29 @@ message ListObjectsRequest {
     }
   ];
 
-  string type = 3 [json_name = "type"];
+  string type = 3 [
+    json_name = "type",
+    (validate.rules).string = {
+      pattern: "^[^:#@\\s]{1,254}$"
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"document\""
+    }
+  ];
 
-  string relation = 4;
-  string user = 5;
+  string relation = 4 [(validate.rules).string = {
+    pattern: "^[^:#@\\s]{1,50}$"
+  }];
+
+  string user = 5 [
+    (validate.rules).string = {
+      max_bytes: 512
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      max_length: 512,
+      example: "\"anne\""
+    }
+  ];
 
   openfga.v1.ContextualTupleKeys contextual_tuples = 6 [json_name = "contextual_tuples"];
 }
@@ -760,10 +779,29 @@ message StreamedListObjectsRequest {
     }
   ];
 
-  string type = 3 [json_name = "type"];
+  string type = 3 [
+    json_name = "type",
+    (validate.rules).string = {
+      pattern: "^[^:#@\\s]{1,254}$"
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "\"document\""
+    }
+  ];
 
-  string relation = 4;
-  string user = 5;
+  string relation = 4 [(validate.rules).string = {
+    pattern: "^[^:#@\\s]{1,50}$"
+  }];
+
+  string user = 5 [
+    (validate.rules).string = {
+      max_bytes: 512
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      max_length: 512,
+      example: "\"anne\""
+    }
+  ];
 
   openfga.v1.ContextualTupleKeys contextual_tuples = 6 [json_name = "contextual_tuples"];
 }


### PR DESCRIPTION
## Description

This PR introduces length restrictions on the `user`, `relation` and `type` parameters of the ListObjects and StreamedListObjects APIs.

The validations for `user` and `relation` are the same as the ones for `TupleKey.user` and `TupleKey.relation`. 

The validation for `type` is the same as the one for `Object.type`.

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
