### PR TITLE
refactor: remove min from contextual tuples

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -1640,7 +1640,7 @@
         },
         "user": {
           "type": "string",
-          "example": "anne",
+          "example": "user:anne",
           "maxLength": 512
         }
       }

--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -1156,7 +1156,6 @@
             "$ref": "#/definitions/TupleKey"
           },
           "maximum": 10,
-          "minimum": 1,
           "required": [
             "tuple_keys"
           ]
@@ -1641,7 +1640,7 @@
         },
         "user": {
           "type": "string",
-          "example": "user:anne",
+          "example": "anne",
           "maxLength": 512
         }
       }

--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -58,7 +58,7 @@ message TupleKey {
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 512,
-      example: "\"anne\""
+      example: "\"user:anne\""
     }
   ];
 }

--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -58,7 +58,7 @@ message TupleKey {
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       max_length: 512,
-      example: "\"user:anne\""
+      example: "\"anne\""
     }
   ];
 }
@@ -86,11 +86,14 @@ message TupleKeys {
 message ContextualTupleKeys {
   repeated TupleKey tuple_keys = 1 [
     (validate.rules).repeated = {
-      max_items: 10
+      min_items: 1,
+      max_items: 10,
+      ignore_empty: true
     },
     json_name = "tuple_keys",
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      minimum: 0,
       maximum: 10
     }
   ];

--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -86,13 +86,11 @@ message TupleKeys {
 message ContextualTupleKeys {
   repeated TupleKey tuple_keys = 1 [
     (validate.rules).repeated = {
-      min_items: 1,
       max_items: 10
     },
     json_name = "tuple_keys",
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      minimum: 1,
       maximum: 10
     }
   ];


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

In Check, we may want to include the contextual tuple field, but with no contextual tuples as in:
```
{
    "authorization_model_id": "01GFVBCAW5QAJVWRMDC82H4Z7D",
    "tuple_key": {
        "object": "repo:openfga/openfga",
        "relation": "reader",
        "user": "anne"
    },
    "contextual_tuples": {
        "tuple_keys": null
    }
}
```

This PR is the change that allows us to do this.

Why do this? It helps in automation.

<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
