### PR TITLE
fix: list object must have user define

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -753,7 +753,8 @@
                 "user": {
                   "type": "string",
                   "example": "user:anne",
-                  "maxLength": 512
+                  "maxLength": 512,
+                  "minLength": 1
                 },
                 "contextual_tuples": {
                   "$ref": "#/definitions/ContextualTupleKeys"
@@ -970,7 +971,8 @@
                 "user": {
                   "type": "string",
                   "example": "user:anne",
-                  "maxLength": 512
+                  "maxLength": 512,
+                  "minLength": 1
                 },
                 "contextual_tuples": {
                   "$ref": "#/definitions/ContextualTupleKeys"

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -682,7 +682,10 @@ message ListObjectsRequest {
   ];
 
   string user = 5 [
-    (validate.rules).string = {min_bytes: 1, max_bytes: 512},
+    (validate.rules).string = {
+      min_bytes: 1,
+      max_bytes: 512
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       min_length: 1,
       max_length: 512,
@@ -728,7 +731,10 @@ message StreamedListObjectsRequest {
   ];
 
   string user = 5 [
-    (validate.rules).string = {min_bytes: 1, max_bytes: 512},
+    (validate.rules).string = {
+      min_bytes: 1,
+      max_bytes: 512
+    },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       min_length: 1,
       max_length: 512,

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -682,8 +682,9 @@ message ListObjectsRequest {
   ];
 
   string user = 5 [
-    (validate.rules).string = {max_bytes: 512},
+    (validate.rules).string = {min_bytes: 1, max_bytes: 512},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      min_length: 1,
       max_length: 512,
       example: "\"user:anne\""
     },
@@ -727,8 +728,9 @@ message StreamedListObjectsRequest {
   ];
 
   string user = 5 [
-    (validate.rules).string = {max_bytes: 512},
+    (validate.rules).string = {min_bytes: 1, max_bytes: 512},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      min_length: 1,
       max_length: 512,
       example: "\"user:anne\""
     },


### PR DESCRIPTION

## Description
Need to specify list object user field must be non empty string.  Currently, non-specified user field are interpreted as empty string.  With the change, ListObject with payload

```
 {
  "type": "resource",
  "relation": "reader"
}
```

will return 

```
{
    "code": "validation_error",
    "message": "invalid ListObjectsRequest.User: value length must be between 1 and 512 bytes, inclusive"
}
```


## References
Close https://github.com/openfga/api/issues/58


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
