### PR TITLE
fix: update contact to point to email

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -5,8 +5,9 @@
     "description": "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar.",
     "version": "0.1",
     "contact": {
-      "name": "community@openfga.dev",
-      "url": "https://openfga.dev"
+      "name": "OpenFGA",
+      "url": "https://openfga.dev",
+      "email": "community@openfga.dev"
     },
     "license": {
       "name": "Apache-2.0",

--- a/openfga/v1/openapi.proto
+++ b/openfga/v1/openapi.proto
@@ -10,7 +10,8 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     description: "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar.";
     version: "0.1";
     contact: {
-      name: "community@openfga.dev";
+      name: "OpenFGA";
+      email: "community@openfga.dev";
       url: "https://openfga.dev";
     };
     license: {


### PR DESCRIPTION

## Description
Update contact section so that it points to the correct email instead of only the website.

## References
Close https://github.com/openfga/openfga.dev/issues/288


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
