### PR TITLE
chore: update versions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
         with:
-          version: "1.9.0"
+          version: "1.15.1"
       - uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
         with:
-          version: "1.9.0"
+          version: "1.15.1"
       - uses: bufbuild/buf-lint-action@v1
       - uses: bufbuild/buf-breaking-action@v1
         with:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
         with:
-          version: "1.9.0"
+          version: "1.15.1"
       - name: "Generate OpenAPI & Diff"
         run: |
           ./buf.gen.yaml

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -10,7 +10,7 @@ managed:
       - buf.build/envoyproxy/protoc-gen-validate
       - buf.build/grpc-ecosystem/grpc-gateway
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/go:v1.28.0-1
+  - remote: buf.build/protocolbuffers/plugins/go:v1.28.1-1
     out: proto/
     opt:
       - paths=source_relative
@@ -23,12 +23,12 @@ plugins:
     opt:
       - paths=source_relative
       - lang=go
-  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.14.0-1
+  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.15.0-1
     out: proto/
     opt:
       - paths=source_relative
       - logtostderr=true
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.14.0-1
+  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.15.0-1
     out: docs/openapiv2
     opt:
       - openapi_naming_strategy=simple


### PR DESCRIPTION
The generated `go.mod` is this:

```
module go.buf.build/openfga/go/openfga/api

go 1.20

require (
	github.com/envoyproxy/protoc-gen-validate v0.10.1
	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
	google.golang.org/genproto v0.0.0-20230327215041-6ac7f18bb9d5
	google.golang.org/grpc v1.54.0
	google.golang.org/protobuf v1.30.0
)

require (
	github.com/golang/protobuf v1.5.3 // indirect
	golang.org/x/net v0.8.0 // indirect
	golang.org/x/sys v0.6.0 // indirect
	golang.org/x/text v0.8.0 // indirect
)
```