### PR TITLE
feat: make schema version a required field

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -1080,7 +1080,10 @@
             "$ref": "#/definitions/TypeDefinition"
           }
         }
-      }
+      },
+      "required": [
+        "schema_version"
+      ]
     },
     "CheckResponse": {
       "type": "object",

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -12,7 +12,10 @@ message AuthorizationModel {
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
   ];
 
-  string schema_version = 2 [json_name = "schema_version"];
+  string schema_version = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    json_name = "schema_version"
+  ];
 
   repeated TypeDefinition type_definitions = 3 [
     json_name = "type_definitions",

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -903,7 +903,7 @@ message WriteAuthorizationModelRequest {
         "1.0",
         "1.1"
       ],
-      ignore_empty: true
+      ignore_empty: false
     }
   ];
 }


### PR DESCRIPTION
Because we want users to explicitly send 1.1. 

I'm not sure when we want to merge this, this is a breaking change ⚠️ 