### PR TITLE
chore: hide unimplemented API definitions

### DIFF
--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -205,65 +205,6 @@
         "tags": [
           "Stores"
         ]
-      },
-      "patch": {
-        "summary": "Update a store",
-        "description": "Updates an existing store.",
-        "operationId": "UpdateStore",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/UpdateStoreResponse"
-            }
-          },
-          "400": {
-            "description": "Request failed due to invalid input.",
-            "schema": {
-              "$ref": "#/definitions/ValidationErrorMessageResponse"
-            }
-          },
-          "404": {
-            "description": "Request failed due to incorrect path.",
-            "schema": {
-              "$ref": "#/definitions/PathUnknownErrorMessageResponse"
-            }
-          },
-          "500": {
-            "description": "Request failed due to internal server error.",
-            "schema": {
-              "$ref": "#/definitions/InternalErrorMessageResponse"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "example": "my-new-store-name"
-                }
-              },
-              "required": [
-                "name"
-              ]
-            }
-          }
-        ],
-        "tags": [
-          "Stores"
-        ]
       }
     },
     "/stores/{store_id}/assertions/{authorization_model_id}": {
@@ -1718,26 +1659,6 @@
       "required": [
         "type"
       ]
-    },
-    "UpdateStoreResponse": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "example": "01YCP46JKYM8FJCQ37NMBYHE5X"
-        },
-        "name": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time"
-        }
-      }
     },
     "Users": {
       "type": "object",

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -4,6 +4,7 @@ package openfga.v1;
 
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
+import "google/api/visibility.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "openfga/v1/authzmodel.proto";
@@ -554,6 +555,8 @@ service OpenFGAService {
   }
 
   rpc UpdateStore(UpdateStoreRequest) returns (UpdateStoreResponse) {
+    option (google.api.method_visibility).restriction = "UNIMPLEMENTED";
+
     option (google.api.http) = {
       patch: "/stores/{store_id}",
       body: "*"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Hides the unimplemented API endpoint to `UpdateStore` until we have an implementation for it.

@andreadistefano - if you end up implementing this API endpoint, please cross-reference.

## References
#74 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
