### PR TITLE
chore: swap deprecated features and switch to official public plugins

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -10,25 +10,24 @@ managed:
       - buf.build/envoyproxy/protoc-gen-validate
       - buf.build/grpc-ecosystem/grpc-gateway
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/go:v1.28.1-1
+  - plugin: buf.build/protocolbuffers/go:v1.28.1
     out: proto/
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc/plugins/go:v1.2.0-1
+  - plugin: buf.build/grpc/go:v1.3.0
     out: proto/
     opt:
       - paths=source_relative
-  - remote: buf.build/jirkad/plugins/protoc-gen-validate:v0.6.7
+  - plugin: buf.build/bufbuild/validate-go:v0.10.1
     out: proto/
     opt:
       - paths=source_relative
-      - lang=go
-  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.15.0-1
+  - plugin: buf.build/grpc-ecosystem/gateway:v2.15.0
     out: proto/
     opt:
       - paths=source_relative
       - logtostderr=true
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.15.0-1
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.0
     out: docs/openapiv2
     opt:
       - openapi_naming_strategy=simple

--- a/buf.lock
+++ b/buf.lock
@@ -4,12 +4,15 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
-    commit: 45685e052c7e406b9fbd441fc7a568a5
+    commit: 6607b10f00ed4a3d98f906807131c44a
+    digest: shake256:acc7b2ededb2f88d296862943a003b157bdb68ec93ed13dcd8566b2d06e47993ea6daf12013b9655658aaf6bbdb141cf65bfe400ce2870f4654b0a5b45e57c09
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 62f35d8aed1149c291d606d958a7ce32
+    commit: 5ae7f88519b04fe1965da0f8a375a088
+    digest: shake256:27d9fcdc0e3eb957449dc3d17e2d24c7ce59c3c483ecf128818183c336dfd28595ecd13771fb3172247775caf7707c4076dd8e70c5ac2cbcac170df35e4d0028
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: bc28b723cd774c32b6fbc77621518765
+    commit: a1ecdc58eccd49aa8bea2a7a9022dc27
+    digest: shake256:efdd86fbdc42e8b7259fe461a49656827a03fb7cba0b3b9eb622ca10654ec6beccb9a051229c1553ccd89ed3e95d69ad4d7c799f1da3f3f1bd447b7947a4893e


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
The Buf team announced a while back that they are deprecating support for the alpha implementation of the Buf Remote Plugins in favor of a more stable and officially maintained public plugins registry. For more information see https://buf.build/docs/bsr/remote-plugins/migrating-from-alpha/

This PR swaps our remote plugins to use the new public plugins provided by Buf, and this eliminates the deprecation warnings that were emitted.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
