### PR TITLE
feat: initial OpenFGA `v2beta1` protobuf API development

### DIFF
--- a/openfga/v2beta1/openfga.proto
+++ b/openfga/v2beta1/openfga.proto
@@ -1,0 +1,163 @@
+syntax = "proto3";
+
+package openfga.v2beta1;
+
+import "google/protobuf/struct.proto";
+
+message RelationshipTuple {
+    
+    Subject subject = 1;
+    
+    string relation = 2;
+    
+    Object object = 3;
+
+    RelationshipCondition condition = 4;
+}
+
+message RelationshipCondition {
+    string name = 1;
+    google.protobuf.Struct context = 2;
+}
+
+message RelationshipTupleWithoutCondition {
+    Subject subject = 1;
+    string relation = 2;
+    Object object = 3;
+}
+
+message Subject {
+    oneof subject_ref{
+        Object object = 1;
+        TypedWildcard typed_wildcard = 2;
+        SubjectSet subject_set = 3;
+    }
+}
+
+message Object {
+    string type = 1;
+    string id = 2;
+}
+
+// TypedWildcard represents the public wildcard of the specified object type.
+// For example, `user:*` represents all objects of the `user` object type.
+message TypedWildcard {
+    string type = 1;
+}
+
+message SubjectSet {
+    Object object = 1;
+    string relation = 2;
+}
+
+message AuthorizationModel {
+    string id = 1;
+    map<string, Relation> relations = 2;
+    map<string, Condition> conditions = 3;
+}
+
+message Relation {
+
+    // The name of the relation.
+    string name = 1;
+
+    // The relationship rewrite rule for the relation.
+    RelationRewrite rewrite = 2;
+
+    // A list of type restrictions that apply to the relation.
+    repeated TypeRestriction type_restrictions = 3;
+}
+
+// RelationRewrite represents a relationship rule that is used to rewrite or define a relation
+// in terms of a direct relationship or some other rewritten relationship definition including
+// through set operations involving union, intersection, and exclusion.
+message RelationRewrite {
+    oneof rewrite_rule {
+        DirectRelationship direct = 1;
+        ComputedRelationship computed = 2;
+        TupleToSubjectSetRelationship tuple_to_subjectset = 3;
+        // union, intersection, exclusion
+    }
+}
+
+// DirectRelationship represents a directly assignable relationship.
+//
+// These relationships are the kinds of relationships that are permissible for writes to an
+// OpenFGA store. The kinds of objects that can be assignable to the directly assignable 
+// relationship are based on the  relations type restrictions.
+message DirectRelationship {}
+
+// ComputedRelationship represents a relationship that is rewritten through a recomputed relation.
+//
+// For example, if a relation `viewer` is rewritten through a computed relationship `editor`. In
+// Zanzibar nomenclature this is identical to computed userset rewrites. 
+message ComputedRelationship {
+    string relation = 1;
+}
+
+// TupleToSubjectSetRelationship represents a relationship 
+//
+// In Zanzibar nomenclature this is identical to tuple to userset rewrites.
+message TupleToSubjectSetRelationship {
+    string tupleset_relation = 1;
+    ComputedRelationship computed_relationship = 2;
+}
+
+// TypeRestriction represents a relationship constraint that applies to a directly
+// assignable relationship. A directl relationship is only permissible if the type
+// restriction allows it.
+message TypeRestriction {
+    oneof type_reference {
+        UnconditionedObjectTypeRestriction unconditioned_object_type_reference = 1;
+        ConditionedObjectTypeRestriction conditioned_object_type_reference = 2;
+        TypedWildcard typed_wildcard_reference = 3;
+        SubjectSetTypeRestriction subject_set_reference = 4;
+    }
+}
+
+// UnconditionedObjectTypeRestriction represents a type restriction that enforces a relationship with
+// only a specific object type and is not conditioned on anything.
+message UnconditionedObjectTypeRestriction {
+    string type = 1;
+}
+
+// ConditionedObjectTypeRestriction represents a type restriction that enforces a relationship with
+// a specific object type and is conditioned on the provided condition name.
+message ConditionedObjectTypeRestriction {
+    string type = 1;
+    string condition = 2;
+}
+
+// SubjectSetTypeRestriction represents a type restriction that references a relation defined on a specific
+// object type. For example `group#member` or `team#admin`.
+message SubjectSetTypeRestriction {
+    string type = 1;
+    string relation = 2;
+}
+
+message Condition {
+    string name = 1;
+    string expression = 2;
+    map<string, ConditionParameterTypeRef> parameters = 3;
+}
+
+message ConditionParameterTypeRef {
+  enum TypeName {
+    TYPE_NAME_UNSPECIFIED = 0;
+    TYPE_NAME_ANY = 1;
+    TYPE_NAME_BOOL = 2;
+    TYPE_NAME_STRING = 3;
+    TYPE_NAME_INT = 4;
+    TYPE_NAME_UINT = 5;
+    TYPE_NAME_DOUBLE = 6;
+    TYPE_NAME_DURATION = 7;
+    TYPE_NAME_TIMESTAMP = 8;
+    TYPE_NAME_MAP = 9;
+    TYPE_NAME_LIST = 10;
+    TYPE_NAME_IPADDRESS = 11;
+  }
+
+  TypeName type_name = 1;
+
+  repeated ConditionParameterTypeRef generic_types = 2;
+}

--- a/openfga/v2beta1/openfga_service.proto
+++ b/openfga/v2beta1/openfga_service.proto
@@ -3,12 +3,13 @@ syntax = "proto3";
 package openfga.v2beta1;
 
 import "google/protobuf/struct.proto";
+import "openfga/v2beta1/openfga.proto";
 
 service OpenFGAService {
     rpc Check(CheckRequest) returns (CheckResponse);
     rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse);
 
-    rpc DeleteRelationships(DeleteRelationshipsRequest) returns (DeleteRelationshipResponse);
+    rpc DeleteRelationships(DeleteRelationshipsRequest) returns (DeleteRelationshipsResponse);
     rpc WriteRelationships(WriteRelationshipsRequest) returns (WriteRelationshipsResponse);
 
     rpc WriteModel(WriteModelRequest) returns (WriteModelResponse);
@@ -31,10 +32,10 @@ message CheckResponse{}
 message ListObjectsRequest{
     string store_id = 1;
     string model_id = 2;
-    Subject subject = 3;
+    openfga.v2beta1.Subject subject = 3;
     string relation = 4;
     string object_type = 5;
-    repeated RelationshipTuple contextual_tuples = 6;
+    repeated openfga.v2beta1.RelationshipTuple contextual_tuples = 6;
     google.protobuf.Struct context = 7;
 }
 message ListObjectsResponse{}
@@ -42,7 +43,7 @@ message ListObjectsResponse{}
 message DeleteRelationshipsRequest{
     string store_id = 1;
 }
-message DeleteRelationshipResponse{}
+message DeleteRelationshipsResponse{}
 
 message WriteRelationshipsRequest{
     string store_id = 1;

--- a/openfga/v2beta1/openfga_service.proto
+++ b/openfga/v2beta1/openfga_service.proto
@@ -3,14 +3,18 @@ syntax = "proto3";
 package openfga.v2beta1;
 
 import "google/protobuf/struct.proto";
+import "google/rpc/status.proto";
 import "openfga/v2beta1/openfga.proto";
 
 service OpenFGAService {
     rpc Check(CheckRequest) returns (CheckResponse);
+    rpc BatchCheck(BatchCheckRequest) returns (BatchCheckResponse);
+
     rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse);
 
-    rpc DeleteRelationships(DeleteRelationshipsRequest) returns (DeleteRelationshipsResponse);
-    rpc WriteRelationships(WriteRelationshipsRequest) returns (WriteRelationshipsResponse);
+    rpc DeleteRelationshipTuples(DeleteRelationshipTuplesRequest) returns (DeleteRelationshipTuplesResponse);
+    rpc WriteRelationshipTuples(WriteRelationshipTuplesRequest) returns (WriteRelationshipTuplesResponse);
+    rpc ReadRelationshipTuples(ReadRelationshipTuplesRequest) returns (ReadRelationshipTuplesResponse);
 
     rpc WriteModel(WriteModelRequest) returns (WriteModelResponse);
     rpc ReadModel(ReadModelRequest) returns (ReadModelResponse);
@@ -29,26 +33,73 @@ message CheckRequest{
 
 message CheckResponse{}
 
+message BatchCheckRequest {
+
+    // One or more individual Check requests to evaluate in the batch.
+    repeated BatchCheckRequestItem requests = 1;
+}
+
+message BatchCheckResponse {
+
+    // The response pairings for each request item and the result/response it produced.
+    repeated BatchCheckResponsePair response_pairs = 1;
+}
+
+// BatchCheckRequestItem represents a single Check request item used in a BatchCheckRequest.
+message BatchCheckRequestItem {
+    Subject subject = 1;
+    string relation = 2;
+    Object object = 3;
+    repeated RelationshipTuple  contextual_tuples = 4;
+    google.protobuf.Struct context = 5;
+}
+
+// BatchCheckResponseItem represents an individual response for a singular BatchCheckRequestItem produced
+// by a BatchCheck RPC.
+message BatchCheckResponseItem {
+    CheckResponse response = 1;
+}
+
+// BatchCheckResponsePair represents the pairing of an individual BatchCheckRequestItem in a
+// BatchCheckRequest and the result which the individual request produced. Each BatchCheckRequestItem
+// can produce either a response item or an error.
+message BatchCheckResponsePair {
+    BatchCheckRequestItem request = 1;
+
+    oneof result {
+        BatchCheckResponseItem response_item = 2;
+        google.rpc.Status error = 3;
+    }
+}
+
 message ListObjectsRequest{
     string store_id = 1;
     string model_id = 2;
-    openfga.v2beta1.Subject subject = 3;
+    Subject subject = 3;
     string relation = 4;
     string object_type = 5;
-    repeated openfga.v2beta1.RelationshipTuple contextual_tuples = 6;
+    RelationshipTuple contextual_tuples = 6;
     google.protobuf.Struct context = 7;
 }
 message ListObjectsResponse{}
 
-message DeleteRelationshipsRequest{
+message DeleteRelationshipTuplesRequest{
     string store_id = 1;
 }
-message DeleteRelationshipsResponse{}
+message DeleteRelationshipTuplesResponse{}
 
-message WriteRelationshipsRequest{
+message WriteRelationshipTuplesRequest{
     string store_id = 1;
 }
-message WriteRelationshipsResponse{}
+message WriteRelationshipTuplesResponse{}
+
+message ReadRelationshipTuplesRequest {
+    string store_id = 1;
+}
+
+message ReadRelationshipTuplesResponse {
+    repeated RelationshipTuple relationship_tuples = 1;
+}
 
 message WriteModelRequest{
     string store_id = 1;

--- a/openfga/v2beta1/openfga_service.proto
+++ b/openfga/v2beta1/openfga_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package openfga.v2beta1;
 
+import "google/protobuf/struct.proto";
+
 service OpenFGAService {
     rpc Check(CheckRequest) returns (CheckResponse);
     rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse);
@@ -14,23 +16,51 @@ service OpenFGAService {
     rpc ListModels(ListModelsRequest) returns (ListModelsResponse);
 }
 
-message CheckRequest{}
+message CheckRequest{
+    string store_id = 1;
+    string model_id = 2;
+    Subject subject = 3;
+    string relation = 4;
+    Object object = 5;
+    repeated RelationshipTuple contextual_tuples = 6;
+    google.protobuf.Struct context = 7;
+}
+
 message CheckResponse{}
 
-message ListObjectsRequest{}
+message ListObjectsRequest{
+    string store_id = 1;
+    string model_id = 2;
+    Subject subject = 3;
+    string relation = 4;
+    string object_type = 5;
+    repeated RelationshipTuple contextual_tuples = 6;
+    google.protobuf.Struct context = 7;
+}
 message ListObjectsResponse{}
 
-message DeleteRelationshipsRequest{}
+message DeleteRelationshipsRequest{
+    string store_id = 1;
+}
 message DeleteRelationshipResponse{}
 
-message WriteRelationshipsRequest{}
+message WriteRelationshipsRequest{
+    string store_id = 1;
+}
 message WriteRelationshipsResponse{}
 
-message WriteModelRequest{}
+message WriteModelRequest{
+    string store_id = 1;
+}
 message WriteModelResponse{}
 
-message ReadModelRequest{}
+message ReadModelRequest{
+    string store_id = 1;
+    string model_id = 2;
+}
 message ReadModelResponse{}
 
-message ListModelsRequest{}
+message ListModelsRequest{
+    string store_id = 1;
+}
 message ListModelsResponse{}

--- a/openfga/v2beta1/openfga_service.proto
+++ b/openfga/v2beta1/openfga_service.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package openfga.v2beta1;
+
+service OpenFGAService {
+    rpc Check(CheckRequest) returns (CheckResponse);
+    rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse);
+
+    rpc DeleteRelationships(DeleteRelationshipsRequest) returns (DeleteRelationshipResponse);
+    rpc WriteRelationships(WriteRelationshipsRequest) returns (WriteRelationshipsResponse);
+
+    rpc WriteModel(WriteModelRequest) returns (WriteModelResponse);
+    rpc ReadModel(ReadModelRequest) returns (ReadModelResponse);
+    rpc ListModels(ListModelsRequest) returns (ListModelsResponse);
+}
+
+message CheckRequest{}
+message CheckResponse{}
+
+message ListObjectsRequest{}
+message ListObjectsResponse{}
+
+message DeleteRelationshipsRequest{}
+message DeleteRelationshipResponse{}
+
+message WriteRelationshipsRequest{}
+message WriteRelationshipsResponse{}
+
+message WriteModelRequest{}
+message WriteModelResponse{}
+
+message ReadModelRequest{}
+message ReadModelResponse{}
+
+message ListModelsRequest{}
+message ListModelsResponse{}

--- a/openfga/v2beta1/watch_service.proto
+++ b/openfga/v2beta1/watch_service.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package watch.v2beta1;
+
+service WatchService {
+
+    // WatchChanges implements a streaming watch over an FGA store's changelog
+    rpc WatchChanges(WatchChangesRequest) returns (stream WatchChangesResponse);
+}
+
+message WatchChangesRequest {}
+message WatchChangesResponse {}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Start the development branch for the `v2beta1` protobuf API definitions for OpenFGA. This is to get things started with that new API development effort as we go into the new year.

As we work through these changes in the scope of this PR, lets try to focus on a few guiding principles:
1. Well typed and strongly typed protobuf API contract - prefer objects over string encoded entities where you can (e.g. `Object` instead of `string object`)

2. Separation of input types vs output types and a clear definition of required vs non-required fields within them- this really helps other development in our tooling such as in the SDKs etc..

3. Think about the gRPC experience, not just the HTTP mapping - the protobuf API is the definitive source of truth. The HTTP API is derived off of it. When in doubt, the protobuf API should take precedence.

4. Give a shit about naming things - if you've had a beef with the API names, speak up and fight for the cause 😄 
5. Encourage strong alignment with [`buf lint` lint style guidelines]( https://buf.build/docs/lint/rules#style-guide) so that we have a standard - we shouldn't have to make exceptions regularly for our protobuf API linting behavior. Stick to the community standard of using `buf lint` and the default rules for it.
6. Consider [Google API Improvement Proposals (AIPs)](https://google.aip.dev/1) as a good starting point for inspiration behind certain API changes and design - we don't have to copy Google API guidelines, but they've clearly given a lot of API experience some thought and since they are the primary driving force behind gRPC and RPC APIs in general, their guidelines are a good reference point for ideas of achieving certain design goals. In particular, consider the AIPs around standard methods.

A few notable changes to get started:
* The new API has been designed with an emphasis on a strongly typed protobuf API. For example, instead of `string object` fields we have explicit `Object object` fields.
* `User` fields have been renamed to `Subject` to avoid confusion with the often defined type name `user`. `Subject` is a strongly typed entity that can be one_of `Object` (a direct object), `TypedWildcard` (to represent the public wildcard), or a `SubjectSet` (to represent the set of subjects that expand to one or more concrete objects). A `SubjectSet` models Usersets in Zanzibar nomenclature.
* `TupleKey` has been more aptly named `RelationshipTuple` - this coincides with our official documentation Concepts better (see [Relationship Tuple](https://openfga.dev/docs/concepts#what-is-a-relationship-tuple))

* `Userset`, which previously represented a relation rewrite rule, has been refactored to a more aptly named `RelationRewrite` and the model of it is much more uniform.
* The relations defined in an AuthorizationModel has changed from a direct `Userset rewrite` field to a map of Relation structures `map<string, Relation>`. This will make things more uniform by far in all application code that deals with an AuthorizationModel structure and will more easily allow for indexing into the model's relation map to grab a particular relation.
* `Relation` now uniformly represents a relation definition, and the constructs associated with it such as the type restrictions that apply to it etc..
* The `ReadChanges` API has been renamed to `WatchChanges` and has been relocated to an auxillary gRPC service definition `WatchService`. This will allow for a separate watch server to implement the WatchService and allow that service to be hosted and scaled independently of the main `OpenFGAService` which services Checks, ListObjects, etc.. The ability to serve and scale this service independently will be more important especially as we start building other features around changelog metadata such as the indexer and `ExpandedWatchChanges` endpoints etc.. These workloads will be different and need not be served from the same server in general..

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
