### PR TITLE
Fix: go.mod module definition introduced conceptual tuples

### DIFF
--- a/proto/go.mod
+++ b/proto/go.mod
@@ -1,6 +1,6 @@
-module go.buf.build/openfga/go/openfga/api
+module github.com/openfga/api/proto
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.4


### PR DESCRIPTION
<!-- Provide a brief summary of the changes -->
Fix module definition in go.mod.
## Description
<!-- Provide a detailed description of the changes -->
Previous PR introduced go.mod module definition that's incorrect. This PR corrects the module definition in go.mod.
## References
[issue-949](https://github.com/openfga/openfga/issues/946)
## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
