### PR TITLE
ci: don't pin version of buf

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,8 +22,6 @@ jobs:
           fetch-depth: 0
 
       - uses: bufbuild/buf-setup-action@9990c72db080fa39cf561230b8d2d7b736681f85 # v1.30.1
-        with:
-          version: "1.28.1"
       - uses: bufbuild/buf-push-action@a654ff18effe4641ebea4a4ce242c49800728459 # v1.2.0
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: bufbuild/buf-setup-action@9990c72db080fa39cf561230b8d2d7b736681f85 # v1.30.1
+      - uses: bufbuild/buf-setup-action@35c243d7f2a909b1d4e40399b348a7fdab27d78d # v1.34.0
       - uses: bufbuild/buf-push-action@a654ff18effe4641ebea4a4ce242c49800728459 # v1.2.0
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           fetch-depth: 0
-      - uses: bufbuild/buf-setup-action@9990c72db080fa39cf561230b8d2d7b736681f85 # v1.30.1
+      - uses: bufbuild/buf-setup-action@35c243d7f2a909b1d4e40399b348a7fdab27d78d # v1.34.0
       - uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # v1.1.1
       - uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1.1.4
         with:
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           fetch-depth: 0
-      - uses: bufbuild/buf-setup-action@9990c72db080fa39cf561230b8d2d7b736681f85 # v1.30.1
+      - uses: bufbuild/buf-setup-action@35c243d7f2a909b1d4e40399b348a7fdab27d78d # v1.34.0
       - name: "Generate OpenAPI & Diff"
         run: |
           make all

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -16,8 +16,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: bufbuild/buf-setup-action@9990c72db080fa39cf561230b8d2d7b736681f85 # v1.30.1
-        with:
-          version: "1.28.1"
       - uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # v1.1.1
       - uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1.1.4
         with:
@@ -32,8 +30,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: bufbuild/buf-setup-action@9990c72db080fa39cf561230b8d2d7b736681f85 # v1.30.1
-        with:
-          version: "1.28.1"
       - name: "Generate OpenAPI & Diff"
         run: |
           make all

--- a/openfga/v1/authzmodel.proto
+++ b/openfga/v1/authzmodel.proto
@@ -10,7 +10,7 @@ message AuthorizationModel {
   string id = 1 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$",
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
       ignore_empty: false
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
@@ -19,7 +19,7 @@ message AuthorizationModel {
   string schema_version = 2 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[1-9].[1-9]$",
+      pattern: "^[1-9].[1-9]$"
       ignore_empty: false
     },
     json_name = "schema_version"
@@ -35,7 +35,7 @@ message AuthorizationModel {
     json_name = "conditions",
     (validate.rules).map.max_pairs = 25,
     (validate.rules).map.keys.string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: false
     }
   ];
@@ -44,7 +44,7 @@ message AuthorizationModel {
 message TypeDefinition {
   string type = 1 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,254}$",
+      pattern: "^[^:#@\\s]{1,254}$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -64,7 +64,7 @@ message TypeDefinition {
 
 message Relation {
   string name = 1 [(validate.rules).string = {
-    pattern: "^[^:#@\\s]{1,50}$",
+    pattern: "^[^:#@\\s]{1,50}$"
     ignore_empty: false
   }];
 
@@ -84,7 +84,7 @@ message Metadata {
   map<string, RelationMetadata> relations = 1;
 
   string module = 2 [(validate.rules).string = {
-    pattern: "^[^:#@\\s]{1,50}$",
+    pattern: "^[^:#@\\s]{1,50}$"
     ignore_empty: true
   }];
 
@@ -93,7 +93,7 @@ message Metadata {
 
 message SourceInfo {
   string file = 1 [(validate.rules).string = {
-    pattern: "^[a-zA-Z0-9_\\-\\/]{1,100}\\.fga$",
+    pattern: "^[a-zA-Z0-9_\\-\\/]{1,100}\\.fga$"
     ignore_empty: true
   }];
 }
@@ -102,7 +102,7 @@ message RelationMetadata {
   repeated RelationReference directly_related_user_types = 1 [json_name = "directly_related_user_types"];
 
   string module = 2 [(validate.rules).string = {
-    pattern: "^[^:#@\\s]{1,50}$",
+    pattern: "^[^:#@\\s]{1,50}$"
     ignore_empty: true
   }];
 
@@ -113,7 +113,7 @@ message RelationMetadata {
 message RelationReference {
   string type = 1 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,254}$",
+      pattern: "^[^:#@\\s]{1,254}$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -123,7 +123,7 @@ message RelationReference {
   oneof relation_or_wildcard {
     string relation = 2 [
       (validate.rules).string = {
-        pattern: "^[^:#@\\s]{1,50}$",
+        pattern: "^[^:#@\\s]{1,50}$"
         ignore_empty: true
       },
       (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"member\""}
@@ -134,7 +134,7 @@ message RelationReference {
 
   // The name of a condition that is enforced over the allowed relation.
   string condition = 4 [(validate.rules).string = {
-    pattern: "^[^:#@\\s]{1,50}$",
+    pattern: "^[^:#@\\s]{1,50}$"
     ignore_empty: true
   }];
 }
@@ -181,7 +181,7 @@ message ComputedUserset {
   string relation = 1 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      max_bytes: 50,
+      max_bytes: 50
       ignore_empty: false
     }
   ];
@@ -204,7 +204,7 @@ message Condition {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: false
     }
   ];
@@ -213,7 +213,7 @@ message Condition {
   string expression = 2 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      max_bytes: 512,
+      max_bytes: 512
       ignore_empty: false
     }
   ];
@@ -229,7 +229,7 @@ message Condition {
 
 message ConditionMetadata {
   string module = 1 [(validate.rules).string = {
-    pattern: "^[^:#@\\s]{1,50}$",
+    pattern: "^[^:#@\\s]{1,50}$"
     ignore_empty: true
   }];
 

--- a/openfga/v1/openapi.proto
+++ b/openfga/v1/openapi.proto
@@ -6,22 +6,22 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
-    title: "OpenFGA";
-    description: "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar.";
-    version: "1.x";
+    title: "OpenFGA"
+    description: "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar."
+    version: "1.x"
     contact: {
-      name: "OpenFGA";
-      email: "community@openfga.dev";
-      url: "https://openfga.dev";
-    };
+      name: "OpenFGA"
+      email: "community@openfga.dev"
+      url: "https://openfga.dev"
+    }
     license: {
-      name: "Apache-2.0";
-      url: "https://github.com/openfga/openfga/blob/main/LICENSE";
-    };
-  };
-  consumes: "application/json";
-  produces: "application/json";
-  schemes: HTTPS;
+      name: "Apache-2.0"
+      url: "https://github.com/openfga/openfga/blob/main/LICENSE"
+    }
+  }
+  consumes: "application/json"
+  produces: "application/json"
+  schemes: HTTPS
   responses: {
     key: "400"
     value: {

--- a/openfga/v1/openfga.proto
+++ b/openfga/v1/openfga.proto
@@ -16,7 +16,7 @@ import "validate/validate.proto";
 message Object {
   string type = 1 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,254}$",
+      pattern: "^[^:#@\\s]{1,254}$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -25,7 +25,7 @@ message Object {
 
   string id = 2 [
     (validate.rules).string = {
-      pattern: "[^#:\\s]+$",
+      pattern: "[^#:\\s]+$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -59,7 +59,7 @@ message User {
 message UsersetUser {
   string type = 1 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,254}$",
+      pattern: "^[^:#@\\s]{1,254}$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -68,7 +68,7 @@ message UsersetUser {
 
   string id = 2 [
     (validate.rules).string = {
-      pattern: "[^#:\\s]+$",
+      pattern: "[^#:\\s]+$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -77,7 +77,7 @@ message UsersetUser {
 
   string relation = 3 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: true
     },
     (google.api.field_behavior) = REQUIRED,
@@ -89,12 +89,12 @@ message RelationshipCondition {
   // A reference (by name) of the relationship condition defined in the authorization model.
   string name = 1 [
     (validate.rules).string = {
-      pattern: "^[^\\s]{2,256}$",
+      pattern: "^[^\\s]{2,256}$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 256,
+      max_length: 256
       example: "\"condition1\""
     }
   ];
@@ -110,7 +110,7 @@ message TupleKeyWithoutCondition {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {max_bytes: 512},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 512,
+      max_length: 512
       example: "\"user:anne\""
     }
   ];
@@ -118,11 +118,11 @@ message TupleKeyWithoutCondition {
   string relation = 2 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 50,
+      max_length: 50
       example: "\"reader\""
     }
   ];
@@ -130,11 +130,11 @@ message TupleKeyWithoutCondition {
   string object = 3 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[^\\s]{2,256}$",
+      pattern: "^[^\\s]{2,256}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 256,
+      max_length: 256
       example: "\"document:2021-budget\""
     }
   ];
@@ -150,7 +150,7 @@ message TupleKeyWithoutCondition {
 message TypedWildcard {
   string type = 1 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,254}$",
+      pattern: "^[^:#@\\s]{1,254}$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -162,11 +162,11 @@ message TupleKey {
   string user = 1 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      max_bytes: 512,
+      max_bytes: 512
       ignore_empty: false
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 512,
+      max_length: 512
       example: "\"user:anne\""
     }
   ];
@@ -174,11 +174,11 @@ message TupleKey {
   string relation = 2 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 50,
+      max_length: 50
       example: "\"reader\""
     }
   ];
@@ -186,11 +186,11 @@ message TupleKey {
   string object = 3 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[^\\s]{2,256}$",
+      pattern: "^[^\\s]{2,256}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 256,
+      max_length: 256
       example: "\"document:2021-budget\""
     }
   ];
@@ -330,7 +330,7 @@ message Store {
 message UserTypeFilter {
   string type = 1 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,254}$",
+      pattern: "^[^:#@\\s]{1,254}$"
       ignore_empty: false
     },
     (google.api.field_behavior) = REQUIRED,
@@ -339,7 +339,7 @@ message UserTypeFilter {
 
   string relation = 2 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"member\""}

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -611,7 +611,7 @@ service OpenFGAService {
 
   rpc CreateStore(CreateStoreRequest) returns (CreateStoreResponse) {
     option (google.api.http) = {
-      post: "/stores",
+      post: "/stores"
       body: "*"
     };
 
@@ -636,7 +636,7 @@ service OpenFGAService {
     option (google.api.method_visibility).restriction = "UNIMPLEMENTED";
 
     option (google.api.http) = {
-      patch: "/stores/{store_id}",
+      patch: "/stores/{store_id}"
       body: "*"
     };
 
@@ -703,7 +703,7 @@ service OpenFGAService {
 
   rpc StreamedListObjects(StreamedListObjectsRequest) returns (stream StreamedListObjectsResponse) {
     option (google.api.http) = {
-      post: "/stores/{store_id}/streamed-list-objects",
+      post: "/stores/{store_id}/streamed-list-objects"
       body: "*"
     };
 
@@ -720,7 +720,7 @@ service OpenFGAService {
 
   rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse) {
     option (google.api.http) = {
-      post: "/stores/{store_id}/list-objects",
+      post: "/stores/{store_id}/list-objects"
       body: "*"
     };
 
@@ -746,7 +746,7 @@ service OpenFGAService {
 
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option (google.api.http) = {
-      post: "/stores/{store_id}/list-users",
+      post: "/stores/{store_id}/list-users"
       body: "*"
     };
 
@@ -784,7 +784,7 @@ message ListObjectsRequest {
   string authorization_model_id = 2 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$",
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
@@ -805,12 +805,12 @@ message ListObjectsRequest {
 
   string user = 5 [
     (validate.rules).string = {
-      min_bytes: 1,
+      min_bytes: 1
       max_bytes: 512
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      min_length: 1,
-      max_length: 512,
+      min_length: 1
+      max_length: 512
       example: "\"user:anne\""
     },
     (google.api.field_behavior) = REQUIRED
@@ -841,7 +841,7 @@ message ListUsersRequest {
   string authorization_model_id = 2 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$",
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
@@ -864,12 +864,12 @@ message ListUsersRequest {
     json_name = "user_filters",
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).repeated = {
-      min_items: 1,
+      min_items: 1
       max_items: 1
     },
 
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "The type of results returned. Only accepts exactly one value.",
+      description: "The type of results returned. Only accepts exactly one value."
       example: "[{\"type\": \"user\"}, {\"type\": \"group\", \"relation\": \"member\"}]"
     }
   ];
@@ -903,7 +903,7 @@ message StreamedListObjectsRequest {
   string authorization_model_id = 2 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$",
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
@@ -924,12 +924,12 @@ message StreamedListObjectsRequest {
 
   string user = 5 [
     (validate.rules).string = {
-      min_bytes: 1,
+      min_bytes: 1
       max_bytes: 512
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      min_length: 1,
-      max_length: 512,
+      min_length: 1
+      max_length: 512
       example: "\"user:anne\""
     },
     (google.api.field_behavior) = REQUIRED
@@ -968,7 +968,7 @@ message ReadRequest {
   google.protobuf.Int32Value page_size = 3 [
     json_name = "page_size",
     (validate.rules).int32 = {
-      gte: 1,
+      gte: 1
       lte: 100
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "50"}
@@ -985,29 +985,29 @@ message ReadRequestTupleKey {
   string user = 1 [
     (validate.rules).string = {max_bytes: 512},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 512,
+      max_length: 512
       example: "\"user:anne\""
     }
   ];
 
   string relation = 2 [
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 50,
+      max_length: 50
       example: "\"reader\""
     }
   ];
 
   string object = 3 [
     (validate.rules).string = {
-      pattern: "^[^\\s]{2,256}$",
+      pattern: "^[^\\s]{2,256}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 256,
+      max_length: 256
       example: "\"document:2021-budget\""
     }
   ];
@@ -1021,7 +1021,7 @@ message ReadResponse {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string.max_bytes = 5120,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "The continuation token will be empty if there are no more tuples.",
+      description: "The continuation token will be empty if there are no more tuples."
       example: "\"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\""
     }
   ];
@@ -1060,7 +1060,7 @@ message WriteRequest {
   string authorization_model_id = 4 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$",
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
@@ -1088,7 +1088,7 @@ message CheckRequest {
   string authorization_model_id = 4 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$",
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
@@ -1096,7 +1096,7 @@ message CheckRequest {
 
   // Defaults to false. Making it true has performance implications.
   bool trace = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-    read_only: true,
+    read_only: true
     example: "false"
   }];
 
@@ -1110,7 +1110,7 @@ message CheckRequestTupleKey {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {pattern: "^[^\\s]{2,512}$"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 512,
+      max_length: 512
       example: "\"user:anne\""
     }
   ];
@@ -1119,7 +1119,7 @@ message CheckRequestTupleKey {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {pattern: "^[^:#@\\s]{1,50}$"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 50,
+      max_length: 50
       example: "\"reader\""
     }
   ];
@@ -1128,7 +1128,7 @@ message CheckRequestTupleKey {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {pattern: "^[^\\s]{2,256}$"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 256,
+      max_length: 256
       example: "\"document:2021-budget\""
     }
   ];
@@ -1158,7 +1158,7 @@ message ExpandRequest {
   string authorization_model_id = 3 [
     json_name = "authorization_model_id",
     (validate.rules).string = {
-      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$",
+      pattern: "^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"01G5JAVJ41T49E9TT3SKVS7X1J\""}
@@ -1169,22 +1169,22 @@ message ExpandRequestTupleKey {
   string relation = 1 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[^:#@\\s]{1,50}$",
+      pattern: "^[^:#@\\s]{1,50}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 50,
+      max_length: 50
       example: "\"reader\""
     }
   ];
   string object = 2 [
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {
-      pattern: "^[^\\s]{2,256}$",
+      pattern: "^[^\\s]{2,256}$"
       ignore_empty: true
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 256,
+      max_length: 256
       example: "\"document:2021-budget\""
     }
   ];
@@ -1237,7 +1237,7 @@ message WriteAuthorizationModelRequest {
         "1.0",
         "1.1",
         "1.2"
-      ],
+      ]
       ignore_empty: false
     }
   ];
@@ -1269,7 +1269,7 @@ message ReadAuthorizationModelsRequest {
   google.protobuf.Int32Value page_size = 2 [
     json_name = "page_size",
     (validate.rules).int32 = {
-      gte: 1,
+      gte: 1
       lte: 100
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "50"}
@@ -1292,7 +1292,7 @@ message ReadAuthorizationModelsResponse {
     json_name = "continuation_token",
     (validate.rules).string.max_bytes = 5120,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "The continuation token will be empty if there are no more models.",
+      description: "The continuation token will be empty if there are no more models."
       example: "\"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\""
     }
   ];
@@ -1317,11 +1317,11 @@ message WriteAssertionsRequest {
     json_name = "assertions",
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).repeated = {
-      min_items: 0,
+      min_items: 0
       max_items: 100
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      minimum: 0,
+      minimum: 0
       maximum: 100
     }
   ];
@@ -1365,14 +1365,14 @@ message ReadChangesRequest {
   ];
 
   string type = 2 [(validate.rules).string = {
-    pattern: "^[^:#\\s]{1,254}$",
+    pattern: "^[^:#\\s]{1,254}$"
     ignore_empty: true
   }];
 
   google.protobuf.Int32Value page_size = 3 [
     json_name = "page_size",
     (validate.rules).int32 = {
-      gte: 1,
+      gte: 1
       lte: 100
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "50"}
@@ -1493,7 +1493,7 @@ message ListStoresRequest {
   google.protobuf.Int32Value page_size = 1 [
     json_name = "page_size",
     (validate.rules).int32 = {
-      gte: 1,
+      gte: 1
       lte: 100
     }
   ];
@@ -1512,7 +1512,7 @@ message ListStoresResponse {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string.max_bytes = 5120,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "The continuation token will be empty if there are no more stores.",
+      description: "The continuation token will be empty if there are no more stores."
       example: "\"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\""
     }
   ];
@@ -1523,7 +1523,7 @@ message AssertionTupleKey {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {pattern: "^[^\\s]{2,256}$"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 256,
+      max_length: 256
       example: "\"document:2021-budget\""
     }
   ];
@@ -1532,7 +1532,7 @@ message AssertionTupleKey {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {pattern: "^[^:#@\\s]{1,50}$"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 50,
+      max_length: 50
       example: "\"reader\""
     }
   ];
@@ -1541,7 +1541,7 @@ message AssertionTupleKey {
     (google.api.field_behavior) = REQUIRED,
     (validate.rules).string = {pattern: "^[^\\s]{2,512}$"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      max_length: 512,
+      max_length: 512
       example: "\"user:anne\""
     }
   ];


### PR DESCRIPTION
## Description

Instead we will use the version that correlates to the action version, so an action upgrade means that we will be running that version of buf in CI. The default for the `version` parameter is changed every buf/buf-setup-action releases, so an upgrade of the action is an upgrade of buf.

Looking through the git blame I don't see a reason why we're pinning buf, it seems to be in place since this repo was started and then sporadically updated.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
