### PR TITLE
doc: correct consistency reference in doc string

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @openfga/backend @openfga/dx
+* @openfga/backend
 docs/ @openfga/dx @openfga/docs

--- a/docs/openapiv2/apidocs.swagger.json
+++ b/docs/openapiv2/apidocs.swagger.json
@@ -1699,7 +1699,7 @@
         "HIGHER_CONSISTENCY"
       ],
       "default": "UNSPECIFIED",
-      "description": "- UNSPECIFIED: Default if not set. Behavior will be the same as MINIMIZE_LATENCY\n - MINIMIZE_LATENCY: Minimize latency at the potential expense of higher consistency.\n - HIGHER_CONSISTENCY: Prefer higher consistency, at the potential expense of increased latency.",
+      "description": "- UNSPECIFIED: Default if not set. Behavior will be the same as MINIMIZE_LATENCY\n - MINIMIZE_LATENCY: Minimize latency at the potential expense of lower consistency.\n - HIGHER_CONSISTENCY: Prefer higher consistency, at the potential expense of increased latency.",
       "title": "Controls the consistency preferences when calling the query APIs.\nbuf:lint:ignore ENUM_ZERO_VALUE_SUFFIX\nbuf:lint:ignore ENUM_VALUE_PREFIX"
     },
     "ContextualTupleKeys": {

--- a/openfga/v1/openfga_service.proto
+++ b/openfga/v1/openfga_service.proto
@@ -780,7 +780,7 @@ service OpenFGAService {
 enum ConsistencyPreference {
   // Default if not set. Behavior will be the same as MINIMIZE_LATENCY
   UNSPECIFIED = 0;
-  // Minimize latency at the potential expense of higher consistency.
+  // Minimize latency at the potential expense of lower consistency.
   MINIMIZE_LATENCY = 100;
   // Prefer higher consistency, at the potential expense of increased latency.
   HIGHER_CONSISTENCY = 200;

--- a/proto/openfga/v1/openfga_service.pb.go
+++ b/proto/openfga/v1/openfga_service.pb.go
@@ -35,7 +35,7 @@ type ConsistencyPreference int32
 const (
 	// Default if not set. Behavior will be the same as MINIMIZE_LATENCY
 	ConsistencyPreference_UNSPECIFIED ConsistencyPreference = 0
-	// Minimize latency at the potential expense of higher consistency.
+	// Minimize latency at the potential expense of lower consistency.
 	ConsistencyPreference_MINIMIZE_LATENCY ConsistencyPreference = 100
 	// Prefer higher consistency, at the potential expense of increased latency.
 	ConsistencyPreference_HIGHER_CONSISTENCY ConsistencyPreference = 200


### PR DESCRIPTION
## Description

Corrects higher to lower on the MINIMIZE_LATENCY doc string

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
