### PR TITLE
CI: pre-commit check for generated files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# AMD = added, modified, deleted
+files=$(git diff --cached --name-only --diff-filter=AMD)
+
+LIGHT_RED='\033[1;31m'
+NC='\033[0m' # No Color
+
+# naive regex check for .proto extension
+if [[ "$files" =~ \.proto ]]
+then
+    # Check if there's a staged diff in /docs
+    result=$(git diff --cached --raw docs/)
+    if [ -n "$result" ]; then
+      # There is a change to docs, exit
+      exit 1
+    else
+      # Don't block, but warn that the docs need updating.
+      echo "This commit contains .proto changes but the docs have not been updated."
+      echo "Your changes were committed, but ${LIGHT_RED}please run 'make all' or this will fail in CI${NC}"
+      exit 1
+    fi
+
+fi
+
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,10 +1,13 @@
 #!/bin/sh
+# This is a simple check to remind people to update the swagger docs
+# if they have made a change to a proto file. It's not iron-clad and non-blocking,
+# but it's better than finding out later in github.
 
 # AMD = added, modified, deleted
 files=$(git diff --cached --name-only --diff-filter=AMD)
 
 LIGHT_RED='\033[1;31m'
-NC='\033[0m' # No Color
+RESET='\033[0m' # No Color
 
 # naive regex check for .proto extension
 if [[ "$files" =~ \.proto ]]
@@ -12,15 +15,13 @@ then
     # Check if there's a staged diff in /docs
     result=$(git diff --cached --raw docs/)
     if [ -n "$result" ]; then
-      # There is a change to docs, exit
-      exit 1
+      # There is a doc update, assume we're ok and exit
+      exit 0
     else
       # Don't block, but warn that the docs need updating.
       echo "This commit contains .proto changes but the docs have not been updated."
-      echo "Your changes were committed, but ${LIGHT_RED}please run 'make all' or this will fail in CI${NC}"
-      exit 1
+      echo "Your changes were committed, but ${LIGHT_RED}please run 'make all' or this will fail in CI${RESET}\n"
     fi
-
 fi
 
-exit 1
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
-# This is a simple check to remind people to update the swagger docs
-# if they have made a change to a proto file. It's not iron-clad and non-blocking,
-# but it's better than finding out later in github.
+# This is a simple check to ensure people remember to regenerate the docs
+# and the pb.go files if they change a .proto file.
+# It's not iron-clad but it's better than finding out later in github.
 
 # AMD = added, modified, deleted
 files=$(git diff --cached --name-only --diff-filter=AMD)
@@ -12,15 +12,17 @@ RESET='\033[0m' # No Color
 # naive regex check for .proto extension
 if [[ "$files" =~ \.proto ]]
 then
-    # Check if there's a staged diff in /docs
-    result=$(git diff --cached --raw docs/)
-    if [ -n "$result" ]; then
-      # There is a doc update, assume we're ok and exit
+    # Check if there's a staged diff in /docs and in the generated pb.go files
+    docs_change=$(git diff --cached --raw docs/)
+    go_change=$(git diff --cached --raw proto/openfga/)
+    if [ -n "$docs_change" ] && [ -n "$go_change" ]; then
+      # Both were changed, we're good
       exit 0
     else
-      # Don't block, but warn that the docs need updating.
-      echo "This commit contains .proto changes but the docs have not been updated."
-      echo "Your changes were committed, but ${LIGHT_RED}please run 'make all' or this will fail in CI${RESET}\n"
+      # One of the two directories does not have changes, block this commit
+      echo "This commit contains .proto changes but either the docs or generated /proto files have not been updated."
+      echo "${LIGHT_RED}Your changes were not committed, please run 'make all' and add the resulting changes${RESET}\n"
+      exit 1
     fi
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,7 +20,7 @@ then
       exit 0
     else
       # One of the two directories does not have changes, block this commit
-      echo "This commit contains .proto changes but either the docs or generated /proto files have not been updated."
+      echo "This commit contains .proto changes but either the docs or generated /proto files are not part of this commit."
       echo "${LIGHT_RED}Your changes were not committed, please run 'make all' and add the resulting changes${RESET}\n"
       exit 1
     fi

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ patch-swagger-doc: buf-gen
 format: buf-gen
 	buf format -w
 
-init-hooks:
+init-git-hooks:
 	git config --local core.hooksPath .githooks/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-all: patch-swagger-doc format
+all: init-hooks patch-swagger-doc format
 
-buf-gen:
+buf-gen: init-hooks
 	./buf.gen.yaml
 
 patch-swagger-doc: buf-gen
@@ -8,3 +8,6 @@ patch-swagger-doc: buf-gen
 
 format: buf-gen
 	buf format -w
+
+init-hooks:
+	git config --local core.hooksPath .githooks/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: patch-swagger-doc format
 
-buf-gen: init-hooks
+buf-gen: init-git-hooks
 	./buf.gen.yaml
 
 patch-swagger-doc: buf-gen

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: init-hooks patch-swagger-doc format
+all: patch-swagger-doc format
 
 buf-gen: init-hooks
 	./buf.gen.yaml

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ To generate source code from the protobuf definitions contained in this project 
 make buf-gen
 ```
 
-The command above will generate source code in the `proto/` directory.
+The command above will generate source code in the `proto/` directory. It will also configure a local git hook to check
+that files requiring auto-generation after `.proto` changes have been updated. There are some cases where that git hook
+may be overly strict. In those cases you can bypass it with `commit --no-verify`.
 
 ## Use the generated sources in OpenFGA
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To generate source code from the protobuf definitions contained in this project 
 > **Note**: You must have [Buf CLI](https://docs.buf.build/installation) installed to run the following command.
 > 
 ```bash
-./buf.gen.yaml
+make buf-gen
 ```
 
 The command above will generate source code in the `proto/` directory.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->
## Description
<!-- Provide a detailed description of the changes -->
<!-- Provide a brief summary of the changes -->
When updating a proto file last week, I forgot to update the docs. We have a github action check for this scenario but it's annoying to have to wait for such a simple fix.

This PR adds a ~non~ blocking pre-commit hook to remind the author if the docs or generated files need updating.

It does the following:

1. If an update to a `.proto` file is being committed
2. Check if the `/docs` and `/proto/openfga/` folder are also being committed
3. If `/docs` and `/proto/openfga/` **are** being committed, hook exits successfully
4. If one of the two above is not being committed, ~remind the author to update the docs but also exit successfully (non-blocking)~ block the commit and remind the author to update the generated files.

https://github.com/user-attachments/assets/c9e710f2-47f9-4d78-ba9e-947879e9754d

